### PR TITLE
Guide Linux users to manual updates

### DIFF
--- a/packages/app/src/app.css
+++ b/packages/app/src/app.css
@@ -135,6 +135,10 @@
     cursor: pointer;
   }
 
+  .link {
+    @apply text-link underline hover:text-zinc-900 dark:hover:text-zinc-100;
+  }
+
   /* Brand wordmark: Literata */
   .kittynode-brand {
     font-family: "Literata Variable", serif;

--- a/packages/app/src/lib/components/UpdateBanner.svelte
+++ b/packages/app/src/lib/components/UpdateBanner.svelte
@@ -1,23 +1,54 @@
 <script lang="ts">
 import { Button } from "$lib/components/ui/button";
-import { Download } from "@lucide/svelte";
+import { ArrowUpRight, Download } from "@lucide/svelte";
 import { updates } from "$stores/updates.svelte";
+import { platform } from "@tauri-apps/plugin-os";
+
+const downloadsUrl = "https://kittynode.com/download";
+const isLinux = platform() === "linux";
 
 const handleInstall = () => updates.installUpdate();
 const handleDismiss = () => updates.dismiss();
 </script>
 
 <div class="p-4 mb-4 border rounded-lg bg-muted flex items-center justify-between">
-  <span class="text-sm">A new version of Kittynode is available! ✨</span>
+  <span class="text-sm">
+    {#if isLinux}
+      A new version of Kittynode is available! Download it from
+      <a
+        href={downloadsUrl}
+        target="_blank"
+        rel="noreferrer noopener"
+        class="link"
+      >
+        kittynode.com/download
+      </a>. ✨
+    {:else}
+      A new version of Kittynode is available! ✨
+    {/if}
+  </span>
   <div class="flex items-center gap-3">
-    <Button
-      size="sm"
-      onclick={handleInstall}
-      disabled={updates.isProcessing}
-    >
-      <Download />
-      {updates.isProcessing ? "Installing..." : "Install update"}
-    </Button>
+    {#if isLinux}
+      <Button
+        size="sm"
+        href={downloadsUrl}
+        target="_blank"
+        rel="noreferrer noopener"
+        class="gap-2"
+      >
+        Open Downloads
+        <ArrowUpRight class="h-4 w-4" />
+      </Button>
+    {:else}
+      <Button
+        size="sm"
+        onclick={handleInstall}
+        disabled={updates.isProcessing}
+      >
+        <Download />
+        {updates.isProcessing ? "Installing..." : "Install update"}
+      </Button>
+    {/if}
     <Button
       size="sm"
       variant="outline"

--- a/packages/app/src/routes/settings/+page.svelte
+++ b/packages/app/src/routes/settings/+page.svelte
@@ -392,43 +392,57 @@ function setRemote(serverUrl: string) {
             </p>
           </div>
           <div class="ml-auto flex items-center gap-2">
-            <Button
-              size="sm"
-              variant={updates.hasUpdate ? "default" : "outline"}
-              disabled={
-                updates.hasUpdate && isLinux
-                  ? updates.isChecking
-                  : updates.isProcessing || updates.isChecking
-              }
-              onclick={
-                updates.hasUpdate
-                  ? isLinux
-                    ? undefined
-                    : handleUpdate
-                  : checkForUpdates
-              }
-              href={updates.hasUpdate && isLinux ? downloadsUrl : undefined}
-              target={updates.hasUpdate && isLinux ? "_blank" : undefined}
-              rel={updates.hasUpdate && isLinux ? "noreferrer noopener" : undefined}
-            >
-              {#if updates.isProcessing && !isLinux}
-                <div class="h-4 w-4 mr-1 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
-                Updating...
-              {:else if updates.isChecking}
-                <div class="h-4 w-4 mr-1 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
-                Checking...
-              {:else if updates.hasUpdate}
-                {#if isLinux}
+            {#if updates.hasUpdate && isLinux}
+              <Button
+                size="sm"
+                variant="default"
+                href={downloadsUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                disabled={updates.isChecking}
+                class="gap-2"
+              >
+                {#if updates.isChecking}
+                  <div class="h-4 w-4 mr-1 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
+                  Checking...
+                {:else}
                   Open Downloads
                   <ArrowUpRight class="h-4 w-4" />
+                {/if}
+              </Button>
+            {:else if updates.hasUpdate}
+              <Button
+                size="sm"
+                variant="default"
+                onclick={handleUpdate}
+                disabled={updates.isProcessing || updates.isChecking}
+              >
+                {#if updates.isProcessing}
+                  <div class="h-4 w-4 mr-1 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
+                  Updating...
+                {:else if updates.isChecking}
+                  <div class="h-4 w-4 mr-1 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
+                  Checking...
                 {:else}
                   <Download class="h-4 w-4 mr-1" />
                   Install Update
                 {/if}
-              {:else}
-                Check Now
-              {/if}
-            </Button>
+              </Button>
+            {:else}
+              <Button
+                size="sm"
+                variant="outline"
+                onclick={checkForUpdates}
+                disabled={updates.isChecking}
+              >
+                {#if updates.isChecking}
+                  <div class="h-4 w-4 mr-1 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
+                  Checking...
+                {:else}
+                  Check Now
+                {/if}
+              </Button>
+            {/if}
           </div>
         </div>
       </Card.Content>


### PR DESCRIPTION
## Summary
- show manual download guidance for Linux in the in-app update banner
- update System Settings update card to link out on Linux while keeping installs on macOS/Windows
- reuse website link styling for consistent outbound links