### PR TITLE
Handle Linux updater checks without AppImage manifest entry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@tauri-apps/plugin-updater": "^2.9.0",
         "ansi-to-html": "^0.7.2",
         "mode-watcher": "^1.1.0",
+        "semver": "^7.7.2",
         "svelte-sonner": "^1.0.5",
       },
       "devDependencies": {
@@ -43,6 +44,7 @@
         "@sveltejs/kit": "^2.37.1",
         "@sveltejs/vite-plugin-svelte": "^6.2.0",
         "@tailwindcss/vite": "^4.1.13",
+        "@types/semver": "^7.5.8",
         "bits-ui": "^2.9.6",
         "clsx": "^2.1.1",
         "svelte": "^5.38.8",
@@ -505,6 +507,8 @@
     "@types/picomatch": ["@types/picomatch@3.0.2", "", {}, "sha512-n0i8TD3UDB7paoMMxA3Y65vUncFJXjcUf7lQY7YyKGl6031FNjfsLs6pdLFCy2GNFxItPJG8GvvpbZc2skH7WA=="],
 
     "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,6 +17,7 @@
     "@tauri-apps/plugin-updater": "^2.9.0",
     "ansi-to-html": "^0.7.2",
     "mode-watcher": "^1.1.0",
+    "semver": "^7.7.2",
     "svelte-sonner": "^1.0.5"
   },
   "devDependencies": {
@@ -26,6 +27,7 @@
     "@sveltejs/adapter-static": "^3.0.9",
     "@sveltejs/kit": "^2.37.1",
     "@sveltejs/vite-plugin-svelte": "^6.2.0",
+    "@types/semver": "^7.5.8",
     "@tailwindcss/vite": "^4.1.13",
     "bits-ui": "^2.9.6",
     "clsx": "^2.1.1",

--- a/packages/app/src/lib/components/UpdateBanner.svelte
+++ b/packages/app/src/lib/components/UpdateBanner.svelte
@@ -2,10 +2,8 @@
 import { Button } from "$lib/components/ui/button";
 import { ArrowUpRight, Download } from "@lucide/svelte";
 import { updates } from "$stores/updates.svelte";
-import { platform } from "@tauri-apps/plugin-os";
 
 const downloadsUrl = "https://kittynode.com/download";
-const isLinux = platform() === "linux";
 
 const handleInstall = () => updates.installUpdate();
 const handleDismiss = () => updates.dismiss();
@@ -13,7 +11,7 @@ const handleDismiss = () => updates.dismiss();
 
 <div class="p-4 mb-4 border rounded-lg bg-muted flex items-center justify-between">
   <span class="text-sm">
-    {#if isLinux}
+    {#if updates.requiresManualInstall}
       A new version of Kittynode is available! Download it from
       <a
         href={downloadsUrl}
@@ -28,7 +26,7 @@ const handleDismiss = () => updates.dismiss();
     {/if}
   </span>
   <div class="flex items-center gap-3">
-    {#if isLinux}
+    {#if updates.requiresManualInstall}
       <Button
         size="sm"
         href={downloadsUrl}

--- a/packages/app/src/routes/settings/+page.svelte
+++ b/packages/app/src/routes/settings/+page.svelte
@@ -35,7 +35,6 @@ let updatingAutoStartDocker = $state(false);
 const autoStartDockerEnabled = $derived(appConfigStore.autoStartDocker);
 const configInitialized = $derived(appConfigStore.initialized);
 const configLoading = $derived(appConfigStore.loading);
-const isLinux = platform() === "linux";
 const downloadsUrl = "https://kittynode.com/download";
 
 onMount(() => {
@@ -149,7 +148,7 @@ async function checkForUpdates() {
       });
     } else {
       notifyInfo("Update available!", {
-        description: isLinux
+        description: updates.requiresManualInstall
           ? "Download the latest version from kittynode.com/download."
           : "A new version of Kittynode is ready to install.",
       });
@@ -373,7 +372,7 @@ function setRemote(serverUrl: string) {
             </p>
             <p class="text-xs text-muted-foreground">
               {#if updates.hasUpdate}
-                {#if isLinux}
+                {#if updates.requiresManualInstall}
                   A new version is available! Download it from
                   <a
                     href={downloadsUrl}
@@ -392,7 +391,7 @@ function setRemote(serverUrl: string) {
             </p>
           </div>
           <div class="ml-auto flex items-center gap-2">
-            {#if updates.hasUpdate && isLinux}
+            {#if updates.requiresManualInstall}
               <Button
                 size="sm"
                 variant="default"


### PR DESCRIPTION
## Summary
- ensure the update store checks the platform before invoking the updater
- fetch latest.json on Linux and use semver to decide when to show the manual download banner
- add semver runtime dependency and types for the comparison helper

## Testing
- just lint-js