### PR TITLE
Add api facade for kittynode core

### DIFF
--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -24,6 +24,11 @@ Kittynode is comprised of several modules that compose together to create seamle
 | `kittynode-app`  | Cross-platform Tauri app with Svelte frontend         |
 | `kittynode-web`  | Web server binding to the core library                |
 
+### Core API Facade
+
+- Consumers import from `kittynode_core::api` and `kittynode_core::api::types` only.
+- Internal layers (`application`, `domain`, `infra`, `manifests`) remain crate-internal to allow refactors without consumer churn.
+
 ## Technology Stack
 
 The entire technology stack was carefully selected so Kittynode can quickly and securely scale development. We plan to audit every single line of code.

--- a/packages/cli/src/commands/delete_package.rs
+++ b/packages/cli/src/commands/delete_package.rs
@@ -1,5 +1,5 @@
 use eyre::Result;
-use kittynode_core::application::delete_package;
+use kittynode_core::api::delete_package;
 
 pub async fn delete_package_cmd(name: String, include_images: bool) -> Result<()> {
     delete_package(&name, include_images).await

--- a/packages/cli/src/commands/get_packages.rs
+++ b/packages/cli/src/commands/get_packages.rs
@@ -1,5 +1,5 @@
 use eyre::Result;
-use kittynode_core::application::get_packages;
+use kittynode_core::api::get_packages;
 
 pub async fn get_packages_cmd() -> Result<()> {
     let packages = get_packages()?;

--- a/packages/cli/src/commands/install_package.rs
+++ b/packages/cli/src/commands/install_package.rs
@@ -1,5 +1,5 @@
 use eyre::Result;
-use kittynode_core::application::install_package;
+use kittynode_core::api::install_package;
 
 pub async fn install_package_cmd(name: String) -> Result<()> {
     install_package(&name).await

--- a/packages/core/src/api/mod.rs
+++ b/packages/core/src/api/mod.rs
@@ -1,0 +1,23 @@
+pub use crate::application::add_capability;
+pub use crate::application::delete_kittynode;
+pub use crate::application::delete_package;
+pub use crate::application::get_capabilities;
+pub use crate::application::get_config;
+pub use crate::application::get_container_logs;
+pub use crate::application::get_installed_packages;
+pub use crate::application::get_onboarding_completed;
+pub use crate::application::get_package_config;
+pub use crate::application::get_packages;
+pub use crate::application::get_server_url;
+pub use crate::application::get_system_info;
+pub use crate::application::init_kittynode;
+pub use crate::application::install_package;
+pub use crate::application::is_docker_running;
+pub use crate::application::remove_capability;
+pub use crate::application::set_auto_start_docker;
+pub use crate::application::set_onboarding_completed;
+pub use crate::application::set_server_url;
+pub use crate::application::start_docker;
+pub use crate::application::update_package_config;
+
+pub mod types;

--- a/packages/core/src/api/types.rs
+++ b/packages/core/src/api/types.rs
@@ -1,0 +1,4 @@
+pub use crate::domain::config::Config;
+pub use crate::domain::logs::LogsQuery;
+pub use crate::domain::package::{Package, PackageConfig};
+pub use crate::domain::system_info::SystemInfo;

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -1,7 +1,8 @@
 // Public modules
-pub mod application;
-pub mod domain;
+pub mod api;
 
 // Internal modules
+mod application;
+mod domain;
 mod infra;
 mod manifests;

--- a/packages/web/src/main.rs
+++ b/packages/web/src/main.rs
@@ -5,9 +5,9 @@ use axum::{
     response::Json,
     routing::{get, post},
 };
-use kittynode_core::domain::logs::LogsQuery;
-use kittynode_core::domain::package::Package;
-use kittynode_core::domain::system_info::SystemInfo;
+use kittynode_core::api::types::LogsQuery;
+use kittynode_core::api::types::Package;
+use kittynode_core::api::types::SystemInfo;
 
 pub(crate) async fn hello_world() -> &'static str {
     "Hello World!"
@@ -16,7 +16,7 @@ pub(crate) async fn hello_world() -> &'static str {
 pub(crate) async fn add_capability(
     Path(name): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    kittynode_core::application::add_capability(&name)
+    kittynode_core::api::add_capability(&name)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(StatusCode::OK)
 }
@@ -24,13 +24,13 @@ pub(crate) async fn add_capability(
 pub(crate) async fn remove_capability(
     Path(name): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    kittynode_core::application::remove_capability(&name)
+    kittynode_core::api::remove_capability(&name)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(StatusCode::OK)
 }
 
 pub(crate) async fn get_capabilities() -> Result<Json<Vec<String>>, (StatusCode, String)> {
-    kittynode_core::application::get_capabilities()
+    kittynode_core::api::get_capabilities()
         .map(Json)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
 }
@@ -38,7 +38,7 @@ pub(crate) async fn get_capabilities() -> Result<Json<Vec<String>>, (StatusCode,
 pub(crate) async fn install_package(
     Path(name): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    kittynode_core::application::install_package(&name)
+    kittynode_core::api::install_package(&name)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(StatusCode::OK)
@@ -47,21 +47,21 @@ pub(crate) async fn install_package(
 pub(crate) async fn delete_package(
     Path(name): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    kittynode_core::application::delete_package(&name, false)
+    kittynode_core::api::delete_package(&name, false)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(StatusCode::OK)
 }
 
 pub(crate) async fn get_installed_packages() -> Result<Json<Vec<Package>>, (StatusCode, String)> {
-    kittynode_core::application::get_installed_packages()
+    kittynode_core::api::get_installed_packages()
         .await
         .map(Json)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
 }
 
 pub(crate) async fn is_docker_running() -> Result<StatusCode, (StatusCode, String)> {
-    match kittynode_core::application::is_docker_running().await {
+    match kittynode_core::api::is_docker_running().await {
         true => Ok(StatusCode::OK),
         false => Err((
             StatusCode::SERVICE_UNAVAILABLE,
@@ -71,19 +71,19 @@ pub(crate) async fn is_docker_running() -> Result<StatusCode, (StatusCode, Strin
 }
 
 pub(crate) async fn init_kittynode() -> Result<StatusCode, (StatusCode, String)> {
-    kittynode_core::application::init_kittynode()
+    kittynode_core::api::init_kittynode()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(StatusCode::OK)
 }
 
 pub(crate) async fn delete_kittynode() -> Result<StatusCode, (StatusCode, String)> {
-    kittynode_core::application::delete_kittynode()
+    kittynode_core::api::delete_kittynode()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(StatusCode::OK)
 }
 
 pub(crate) async fn get_system_info() -> Result<Json<SystemInfo>, (StatusCode, String)> {
-    kittynode_core::application::get_system_info()
+    kittynode_core::api::get_system_info()
         .map(Json)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
 }
@@ -92,7 +92,7 @@ pub(crate) async fn get_container_logs(
     Path(container_name): Path<String>,
     Query(params): Query<LogsQuery>,
 ) -> Result<Json<Vec<String>>, (StatusCode, String)> {
-    kittynode_core::application::get_container_logs(&container_name, params.tail)
+    kittynode_core::api::get_container_logs(&container_name, params.tail)
         .await
         .map(Json)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))


### PR DESCRIPTION
## Summary
- add kittynode_core::api facade that re-exports the existing application functions
- expose domain data models via api::types so consumers pull from a single entry point
- update CLI, app, and web consumers along with architecture docs to describe the new boundary

## Testing
- just lint-rs
- just test
