### PR TITLE
Align app adapters with core API casing

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -22,7 +22,19 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "@tauri-apps/api/core": {
+                "message": "Import invoke via $lib/client instead of using @tauri-apps/api/core directly."
+              }
+            }
+          }
+        }
+      }
     }
   },
   "assist": {
@@ -57,6 +69,16 @@
       ],
       "linter": {
         "enabled": false
+      }
+    },
+    {
+      "includes": ["packages/app/src/lib/client.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": "off"
+          }
+        }
       }
     }
   ]

--- a/packages/app/src/lib/client.ts
+++ b/packages/app/src/lib/client.ts
@@ -5,190 +5,8 @@ import type {
   OperationalState,
   Package,
   PackageConfig,
-  PortBinding,
   SystemInfo,
 } from "$lib/types";
-
-type RawKittynodeConfig = {
-  capabilities?: string[];
-  server_url?: string;
-  onboarding_completed?: boolean;
-  auto_start_docker?: boolean;
-};
-
-type RawOperationalState = {
-  mode: OperationalState["mode"];
-  docker_running: boolean;
-  can_install: boolean;
-  can_manage: boolean;
-  diagnostics?: string[];
-};
-
-type RawPackage = {
-  name: string;
-  description: string;
-  network_name: string;
-  default_config: PackageConfig;
-  containers: RawContainer[];
-};
-
-type RawContainer = {
-  name: string;
-  image: string;
-  cmd: string[];
-  port_bindings: Record<string, RawPortBinding[]>;
-  volume_bindings: RawBinding[];
-  file_bindings: RawBinding[];
-};
-
-type RawBinding = {
-  source: string;
-  destination: string;
-  options?: string;
-};
-
-type RawPortBinding = {
-  host_ip?: string | null;
-  host_port?: string | null;
-};
-
-type RawPackagesResponse = Record<string, RawPackage>;
-
-type RawSystemInfo = {
-  processor: {
-    name: string;
-    cores: number;
-    frequency_ghz: number;
-    architecture: string;
-  };
-  memory: {
-    total_bytes: number;
-    total_display: string;
-  };
-  storage: {
-    disks: RawDiskInfo[];
-  };
-};
-
-type RawDiskInfo = {
-  name: string;
-  mount_point: string;
-  total_bytes: number;
-  available_bytes: number;
-  total_display: string;
-  used_display: string;
-  available_display: string;
-  disk_type: string;
-};
-
-function transformConfig(
-  raw: RawKittynodeConfig | null | undefined,
-): KittynodeConfig {
-  return {
-    capabilities: raw?.capabilities ?? [],
-    serverUrl: raw?.server_url ?? "",
-    onboardingCompleted: raw?.onboarding_completed ?? false,
-    autoStartDocker: raw?.auto_start_docker ?? false,
-  };
-}
-
-function transformOperationalState(raw: RawOperationalState): OperationalState {
-  return {
-    mode: raw.mode,
-    dockerRunning: raw.docker_running,
-    canInstall: raw.can_install,
-    canManage: raw.can_manage,
-    diagnostics: raw.diagnostics ?? [],
-  };
-}
-
-function transformPackages(raw: RawPackagesResponse): Record<string, Package> {
-  return Object.fromEntries(
-    Object.entries(raw).map(([name, pkg]) => [name, transformPackage(pkg)]),
-  );
-}
-
-function transformPackage(raw: RawPackage): Package {
-  return {
-    name: raw.name,
-    description: raw.description,
-    networkName: raw.network_name,
-    defaultConfig: raw.default_config,
-    containers: raw.containers.map(transformContainer),
-  };
-}
-
-function transformContainer(raw: RawContainer): Package["containers"][number] {
-  return {
-    name: raw.name,
-    image: raw.image,
-    cmd: [...raw.cmd],
-    portBindings: transformPortBindings(raw.port_bindings),
-    volumeBindings: raw.volume_bindings.map(transformBinding),
-    fileBindings: raw.file_bindings.map(transformBinding),
-  };
-}
-
-function transformBinding(
-  raw: RawBinding,
-): Package["containers"][number]["volumeBindings"][number] {
-  return {
-    source: raw.source,
-    destination: raw.destination,
-    options: raw.options,
-  };
-}
-
-function transformPortBindings(
-  raw: Record<string, RawPortBinding[]>,
-): Record<string, PortBinding[]> {
-  return Object.fromEntries(
-    Object.entries(raw).map(([key, bindings]) => [
-      key,
-      bindings.map(transformPortBinding),
-    ]),
-  );
-}
-
-function transformPortBinding(raw: RawPortBinding): PortBinding {
-  return {
-    hostIp: raw.host_ip ?? null,
-    hostPort: raw.host_port ?? null,
-  };
-}
-
-function transformSystemInfo(raw: RawSystemInfo): SystemInfo {
-  return {
-    processor: {
-      name: raw.processor.name,
-      cores: raw.processor.cores,
-      frequencyGhz: raw.processor.frequency_ghz,
-      architecture: raw.processor.architecture,
-    },
-    memory: {
-      totalBytes: raw.memory.total_bytes,
-      totalDisplay: raw.memory.total_display,
-    },
-    storage: {
-      disks: raw.storage.disks.map(transformDiskInfo),
-    },
-  };
-}
-
-function transformDiskInfo(
-  raw: RawDiskInfo,
-): SystemInfo["storage"]["disks"][number] {
-  return {
-    name: raw.name,
-    mountPoint: raw.mount_point,
-    totalBytes: raw.total_bytes,
-    availableBytes: raw.available_bytes,
-    totalDisplay: raw.total_display,
-    usedDisplay: raw.used_display,
-    availableDisplay: raw.available_display,
-    diskType: raw.disk_type,
-  };
-}
 
 export type DockerStartStatus =
   | "running"
@@ -202,85 +20,81 @@ export interface LatestManifest {
 
 export const coreClient = {
   getPackages(): Promise<Record<string, Package>> {
-    return invoke<RawPackagesResponse>("get_packages").then(transformPackages);
+    return invoke("get_packages");
   },
 
   getInstalledPackages(): Promise<Package[]> {
-    return invoke<RawPackage[]>("get_installed_packages").then((packages) =>
-      packages.map(transformPackage),
-    );
+    return invoke("get_installed_packages");
   },
 
   installPackage(name: string): Promise<void> {
-    return invoke<void>("install_package", { name });
+    return invoke("install_package", { name });
   },
 
   deletePackage(name: string, includeImages: boolean): Promise<void> {
-    return invoke<void>("delete_package", { name, includeImages });
+    return invoke("delete_package", { name, includeImages });
   },
 
   getContainerLogs(
     containerName: string,
     tailLines: number | null,
   ): Promise<string[]> {
-    return invoke<string[]>("get_container_logs", { containerName, tailLines });
+    return invoke("get_container_logs", { containerName, tailLines });
   },
 
   getOperationalState(): Promise<OperationalState> {
-    return invoke<RawOperationalState>("get_operational_state").then(
-      transformOperationalState,
-    );
+    return invoke("get_operational_state");
   },
 
   startDockerIfNeeded(): Promise<DockerStartStatus> {
-    return invoke<DockerStartStatus>("start_docker_if_needed");
+    return invoke("start_docker_if_needed");
   },
 
   initKittynode(): Promise<void> {
-    return invoke<void>("init_kittynode");
+    return invoke("init_kittynode");
   },
 
   setOnboardingCompleted(completed: boolean): Promise<void> {
-    return invoke<void>("set_onboarding_completed", { completed });
+    return invoke("set_onboarding_completed", { completed });
   },
 
   getOnboardingCompleted(): Promise<boolean> {
-    return invoke<boolean>("get_onboarding_completed");
+    return invoke("get_onboarding_completed");
   },
 
   getConfig(): Promise<KittynodeConfig> {
-    return invoke<RawKittynodeConfig>("get_config").then(transformConfig);
+    return invoke("get_config");
   },
 
   setAutoStartDocker(enabled: boolean): Promise<void> {
-    return invoke<void>("set_auto_start_docker", { enabled });
+    return invoke("set_auto_start_docker", { enabled });
   },
 
   setServerUrl(endpoint: string): Promise<void> {
-    return invoke<void>("set_server_url", { endpoint });
+    return invoke("set_server_url", { endpoint });
   },
 
   getSystemInfo(): Promise<SystemInfo> {
-    return invoke<RawSystemInfo>("system_info").then(transformSystemInfo);
+    return invoke("system_info");
   },
 
   getPackageConfig(name: string): Promise<PackageConfig> {
-    return invoke<PackageConfig>("get_package_config", { name });
+    return invoke("get_package_config", { name });
   },
 
   updatePackageConfig(name: string, config: PackageConfig): Promise<void> {
-    return invoke<void>("update_package_config", { name, config });
+    return invoke("update_package_config", { name, config });
   },
 
   deleteKittynode(): Promise<void> {
-    return invoke<void>("delete_kittynode");
+    return invoke("delete_kittynode");
   },
 
   restartApp(): Promise<void> {
-    return invoke<void>("restart_app");
+    return invoke("restart_app");
   },
 
   fetchLatestManifest(url: string): Promise<LatestManifest> {
-    return invoke<LatestManifest>("fetch_latest_manifest", { url });
+    return invoke("fetch_latest_manifest", { url });
   },
 };

--- a/packages/app/src/lib/client.ts
+++ b/packages/app/src/lib/client.ts
@@ -1,0 +1,286 @@
+import { invoke } from "@tauri-apps/api/core";
+
+import type {
+  KittynodeConfig,
+  OperationalState,
+  Package,
+  PackageConfig,
+  PortBinding,
+  SystemInfo,
+} from "$lib/types";
+
+type RawKittynodeConfig = {
+  capabilities?: string[];
+  server_url?: string;
+  onboarding_completed?: boolean;
+  auto_start_docker?: boolean;
+};
+
+type RawOperationalState = {
+  mode: OperationalState["mode"];
+  docker_running: boolean;
+  can_install: boolean;
+  can_manage: boolean;
+  diagnostics?: string[];
+};
+
+type RawPackage = {
+  name: string;
+  description: string;
+  network_name: string;
+  default_config: PackageConfig;
+  containers: RawContainer[];
+};
+
+type RawContainer = {
+  name: string;
+  image: string;
+  cmd: string[];
+  port_bindings: Record<string, RawPortBinding[]>;
+  volume_bindings: RawBinding[];
+  file_bindings: RawBinding[];
+};
+
+type RawBinding = {
+  source: string;
+  destination: string;
+  options?: string;
+};
+
+type RawPortBinding = {
+  host_ip?: string | null;
+  host_port?: string | null;
+};
+
+type RawPackagesResponse = Record<string, RawPackage>;
+
+type RawSystemInfo = {
+  processor: {
+    name: string;
+    cores: number;
+    frequency_ghz: number;
+    architecture: string;
+  };
+  memory: {
+    total_bytes: number;
+    total_display: string;
+  };
+  storage: {
+    disks: RawDiskInfo[];
+  };
+};
+
+type RawDiskInfo = {
+  name: string;
+  mount_point: string;
+  total_bytes: number;
+  available_bytes: number;
+  total_display: string;
+  used_display: string;
+  available_display: string;
+  disk_type: string;
+};
+
+function transformConfig(
+  raw: RawKittynodeConfig | null | undefined,
+): KittynodeConfig {
+  return {
+    capabilities: raw?.capabilities ?? [],
+    serverUrl: raw?.server_url ?? "",
+    onboardingCompleted: raw?.onboarding_completed ?? false,
+    autoStartDocker: raw?.auto_start_docker ?? false,
+  };
+}
+
+function transformOperationalState(raw: RawOperationalState): OperationalState {
+  return {
+    mode: raw.mode,
+    dockerRunning: raw.docker_running,
+    canInstall: raw.can_install,
+    canManage: raw.can_manage,
+    diagnostics: raw.diagnostics ?? [],
+  };
+}
+
+function transformPackages(raw: RawPackagesResponse): Record<string, Package> {
+  return Object.fromEntries(
+    Object.entries(raw).map(([name, pkg]) => [name, transformPackage(pkg)]),
+  );
+}
+
+function transformPackage(raw: RawPackage): Package {
+  return {
+    name: raw.name,
+    description: raw.description,
+    networkName: raw.network_name,
+    defaultConfig: raw.default_config,
+    containers: raw.containers.map(transformContainer),
+  };
+}
+
+function transformContainer(raw: RawContainer): Package["containers"][number] {
+  return {
+    name: raw.name,
+    image: raw.image,
+    cmd: [...raw.cmd],
+    portBindings: transformPortBindings(raw.port_bindings),
+    volumeBindings: raw.volume_bindings.map(transformBinding),
+    fileBindings: raw.file_bindings.map(transformBinding),
+  };
+}
+
+function transformBinding(
+  raw: RawBinding,
+): Package["containers"][number]["volumeBindings"][number] {
+  return {
+    source: raw.source,
+    destination: raw.destination,
+    options: raw.options,
+  };
+}
+
+function transformPortBindings(
+  raw: Record<string, RawPortBinding[]>,
+): Record<string, PortBinding[]> {
+  return Object.fromEntries(
+    Object.entries(raw).map(([key, bindings]) => [
+      key,
+      bindings.map(transformPortBinding),
+    ]),
+  );
+}
+
+function transformPortBinding(raw: RawPortBinding): PortBinding {
+  return {
+    hostIp: raw.host_ip ?? null,
+    hostPort: raw.host_port ?? null,
+  };
+}
+
+function transformSystemInfo(raw: RawSystemInfo): SystemInfo {
+  return {
+    processor: {
+      name: raw.processor.name,
+      cores: raw.processor.cores,
+      frequencyGhz: raw.processor.frequency_ghz,
+      architecture: raw.processor.architecture,
+    },
+    memory: {
+      totalBytes: raw.memory.total_bytes,
+      totalDisplay: raw.memory.total_display,
+    },
+    storage: {
+      disks: raw.storage.disks.map(transformDiskInfo),
+    },
+  };
+}
+
+function transformDiskInfo(
+  raw: RawDiskInfo,
+): SystemInfo["storage"]["disks"][number] {
+  return {
+    name: raw.name,
+    mountPoint: raw.mount_point,
+    totalBytes: raw.total_bytes,
+    availableBytes: raw.available_bytes,
+    totalDisplay: raw.total_display,
+    usedDisplay: raw.used_display,
+    availableDisplay: raw.available_display,
+    diskType: raw.disk_type,
+  };
+}
+
+export type DockerStartStatus =
+  | "running"
+  | "disabled"
+  | "already_started"
+  | "starting";
+
+export interface LatestManifest {
+  version: string;
+}
+
+export const coreClient = {
+  getPackages(): Promise<Record<string, Package>> {
+    return invoke<RawPackagesResponse>("get_packages").then(transformPackages);
+  },
+
+  getInstalledPackages(): Promise<Package[]> {
+    return invoke<RawPackage[]>("get_installed_packages").then((packages) =>
+      packages.map(transformPackage),
+    );
+  },
+
+  installPackage(name: string): Promise<void> {
+    return invoke<void>("install_package", { name });
+  },
+
+  deletePackage(name: string, includeImages: boolean): Promise<void> {
+    return invoke<void>("delete_package", { name, includeImages });
+  },
+
+  getContainerLogs(
+    containerName: string,
+    tailLines: number | null,
+  ): Promise<string[]> {
+    return invoke<string[]>("get_container_logs", { containerName, tailLines });
+  },
+
+  getOperationalState(): Promise<OperationalState> {
+    return invoke<RawOperationalState>("get_operational_state").then(
+      transformOperationalState,
+    );
+  },
+
+  startDockerIfNeeded(): Promise<DockerStartStatus> {
+    return invoke<DockerStartStatus>("start_docker_if_needed");
+  },
+
+  initKittynode(): Promise<void> {
+    return invoke<void>("init_kittynode");
+  },
+
+  setOnboardingCompleted(completed: boolean): Promise<void> {
+    return invoke<void>("set_onboarding_completed", { completed });
+  },
+
+  getOnboardingCompleted(): Promise<boolean> {
+    return invoke<boolean>("get_onboarding_completed");
+  },
+
+  getConfig(): Promise<KittynodeConfig> {
+    return invoke<RawKittynodeConfig>("get_config").then(transformConfig);
+  },
+
+  setAutoStartDocker(enabled: boolean): Promise<void> {
+    return invoke<void>("set_auto_start_docker", { enabled });
+  },
+
+  setServerUrl(endpoint: string): Promise<void> {
+    return invoke<void>("set_server_url", { endpoint });
+  },
+
+  getSystemInfo(): Promise<SystemInfo> {
+    return invoke<RawSystemInfo>("system_info").then(transformSystemInfo);
+  },
+
+  getPackageConfig(name: string): Promise<PackageConfig> {
+    return invoke<PackageConfig>("get_package_config", { name });
+  },
+
+  updatePackageConfig(name: string, config: PackageConfig): Promise<void> {
+    return invoke<void>("update_package_config", { name, config });
+  },
+
+  deleteKittynode(): Promise<void> {
+    return invoke<void>("delete_kittynode");
+  },
+
+  restartApp(): Promise<void> {
+    return invoke<void>("restart_app");
+  },
+
+  fetchLatestManifest(url: string): Promise<LatestManifest> {
+    return invoke<LatestManifest>("fetch_latest_manifest", { url });
+  },
+};

--- a/packages/app/src/lib/components/DockerLogs.svelte
+++ b/packages/app/src/lib/components/DockerLogs.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onMount, onDestroy } from "svelte";
-import { invoke } from "@tauri-apps/api/core";
+import { coreClient } from "$lib/client";
 import Convert from "ansi-to-html";
 
 const convert = new Convert();
@@ -17,10 +17,7 @@ let polling: NodeJS.Timeout;
 
 async function fetchLogs() {
   try {
-    const newLogs = await invoke<string[]>("get_container_logs", {
-      containerName,
-      tailLines,
-    });
+    const newLogs = await coreClient.getContainerLogs(containerName, tailLines);
 
     // Convert ANSI escape sequences to HTML
     logs = newLogs.map((log) => convert.toHtml(log));

--- a/packages/app/src/lib/types/index.ts
+++ b/packages/app/src/lib/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./package";
 export * from "./config";
 export * from "./operational_state";
+export * from "./system_info";

--- a/packages/app/src/lib/types/package.ts
+++ b/packages/app/src/lib/types/package.ts
@@ -1,17 +1,27 @@
 export interface Package {
   name: string;
   description: string;
-  network_name: string;
+  networkName: string;
+  defaultConfig: PackageConfig;
   containers: Container[];
+}
+
+export interface PackageConfig {
+  values: Record<string, string>;
 }
 
 export interface Container {
   name: string;
   image: string;
   cmd: string[];
-  port_bindings: Record<string, { host_ip: string; host_port: string }[]>;
-  volume_bindings: Binding[];
-  file_bindings: Binding[];
+  portBindings: Record<string, PortBinding[]>;
+  volumeBindings: Binding[];
+  fileBindings: Binding[];
+}
+
+export interface PortBinding {
+  hostIp?: string | null;
+  hostPort?: string | null;
 }
 
 export interface Binding {

--- a/packages/app/src/lib/types/system_info.ts
+++ b/packages/app/src/lib/types/system_info.ts
@@ -7,13 +7,13 @@ export interface SystemInfo {
 export interface ProcessorInfo {
   name: string;
   cores: number;
-  frequency_ghz: number;
+  frequencyGhz: number;
   architecture: string;
 }
 
 export interface MemoryInfo {
-  total_bytes: number;
-  total_display: string;
+  totalBytes: number;
+  totalDisplay: string;
 }
 
 export interface StorageInfo {
@@ -22,11 +22,11 @@ export interface StorageInfo {
 
 export interface DiskInfo {
   name: string;
-  mount_point: string;
-  total_bytes: number;
-  available_bytes: number;
-  total_display: string;
-  used_display: string;
-  available_display: string;
-  disk_type: string;
+  mountPoint: string;
+  totalBytes: number;
+  availableBytes: number;
+  totalDisplay: string;
+  usedDisplay: string;
+  availableDisplay: string;
+  diskType: string;
 }

--- a/packages/app/src/routes/+layout.svelte
+++ b/packages/app/src/routes/+layout.svelte
@@ -10,7 +10,7 @@ import { platform } from "@tauri-apps/plugin-os";
 import { updates } from "$stores/updates.svelte";
 import { Toaster } from "svelte-sonner";
 import { getVersion } from "@tauri-apps/api/app";
-import { invoke } from "@tauri-apps/api/core";
+import { coreClient } from "$lib/client";
 import { Button } from "$lib/components/ui/button";
 import UpdateBanner from "$lib/components/UpdateBanner.svelte";
 import * as Sidebar from "$lib/components/ui/sidebar";
@@ -64,7 +64,7 @@ onMount(async () => {
 
   // Check if onboarding has been completed
   try {
-    onboardingCompleted = await invoke("get_onboarding_completed");
+    onboardingCompleted = await coreClient.getOnboardingCompleted();
     if (onboardingCompleted) {
       // Skip splash screen without re-initializing config
       // Just set the initialized flag to bypass the splash

--- a/packages/app/src/routes/Home.svelte
+++ b/packages/app/src/routes/Home.svelte
@@ -157,7 +157,7 @@ onDestroy(() => {
         </Card.Header>
         <Card.Content>
           <div class="text-2xl font-bold">
-            {systemInfoStore.systemInfo.memory.total_display}
+            {systemInfoStore.systemInfo.memory.totalDisplay}
           </div>
           <p class="text-xs text-muted-foreground">
             Total System Memory

--- a/packages/app/src/routes/Splash.svelte
+++ b/packages/app/src/routes/Splash.svelte
@@ -2,7 +2,7 @@
 import { initializedStore } from "$stores/initialized.svelte";
 import { goto } from "$app/navigation";
 import { platform } from "@tauri-apps/plugin-os";
-import { invoke } from "@tauri-apps/api/core";
+import { coreClient } from "$lib/client";
 import { onMount } from "svelte";
 import { mode } from "mode-watcher";
 import { toast } from "svelte-sonner";
@@ -23,7 +23,7 @@ async function initKittynode() {
     }
     // Mark onboarding as completed
     try {
-      await invoke("set_onboarding_completed", { completed: true });
+      await coreClient.setOnboardingCompleted(true);
     } catch (e) {
       console.error(`Failed to save onboarding state: ${e}`);
       toast.error("Failed to save onboarding progress");

--- a/packages/app/src/routes/settings/+page.svelte
+++ b/packages/app/src/routes/settings/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { invoke } from "@tauri-apps/api/core";
+import { coreClient } from "$lib/client";
 import { Button } from "$lib/components/ui/button";
 import * as Card from "$lib/components/ui/card";
 import { platform } from "@tauri-apps/plugin-os";
@@ -129,9 +129,9 @@ async function disconnectRemote() {
 
 async function deleteKittynode() {
   try {
-    await invoke("delete_kittynode");
+    await coreClient.deleteKittynode();
     // Immediately restart the app with fresh config
-    await invoke("restart_app");
+    await coreClient.restartApp();
   } catch (e) {
     notifyError("Failed to delete Kittynode data", e);
   }

--- a/packages/app/src/routes/system-info/+page.svelte
+++ b/packages/app/src/routes/system-info/+page.svelte
@@ -113,7 +113,7 @@ onMount(() => {
             </div>
             <div>
               <p class="text-muted-foreground">Frequency</p>
-              <p class="font-medium">{systemInfoStore.systemInfo.processor.frequency_ghz.toFixed(2)} GHz</p>
+              <p class="font-medium">{systemInfoStore.systemInfo.processor.frequencyGhz.toFixed(2)} GHz</p>
             </div>
           </div>
           <div>
@@ -133,7 +133,7 @@ onMount(() => {
         <Card.Content class="space-y-2">
           <div>
             <p class="text-sm text-muted-foreground">Total System Memory</p>
-            <p class="text-2xl font-bold">{systemInfoStore.systemInfo.memory.total_display}</p>
+            <p class="text-2xl font-bold">{systemInfoStore.systemInfo.memory.totalDisplay}</p>
           </div>
           <div class="pt-2">
             <p class="text-xs text-muted-foreground">
@@ -158,8 +158,8 @@ onMount(() => {
       <Card.Content class="space-y-4">
         {#each systemInfoStore.systemInfo.storage.disks as disk}
           {@const usagePercent = calculateUsagePercentage(
-            disk.total_bytes - disk.available_bytes,
-            disk.total_bytes
+            disk.totalBytes - disk.availableBytes,
+            disk.totalBytes
           )}
           <div class="space-y-2">
             <div class="flex items-center justify-between">
@@ -169,7 +169,7 @@ onMount(() => {
             </div>
             <Progress value={usagePercent} max={100} />
             <div class="flex justify-between text-xs text-muted-foreground">
-              <span>{disk.used_display} of {disk.total_display} used</span>
+              <span>{disk.usedDisplay} of {disk.totalDisplay} used</span>
             </div>
           </div>
         {/each}

--- a/packages/app/src/stores/initialized.svelte.ts
+++ b/packages/app/src/stores/initialized.svelte.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { coreClient } from "$lib/client";
 
 type InitState = "idle" | "initializing" | "initialized";
 
@@ -20,7 +20,7 @@ export const initializedStore = {
     }
     state = "initializing";
     try {
-      await invoke("init_kittynode");
+      await coreClient.initKittynode();
       state = "initialized";
     } catch (error) {
       state = "idle";

--- a/packages/app/src/stores/packageConfig.svelte.ts
+++ b/packages/app/src/stores/packageConfig.svelte.ts
@@ -1,23 +1,15 @@
-import { invoke } from "@tauri-apps/api/core";
-
-interface PackageConfig {
-  values: Record<string, string>;
-}
+import { coreClient } from "$lib/client";
+import type { PackageConfig } from "$lib/types";
 
 export const packageConfigStore = {
   async getConfig(packageName: string): Promise<PackageConfig> {
-    return await invoke("get_package_config", {
-      name: packageName,
-    });
+    return await coreClient.getPackageConfig(packageName);
   },
 
   async updateConfig(
     packageName: string,
     config: PackageConfig,
   ): Promise<void> {
-    await invoke("update_package_config", {
-      name: packageName,
-      config,
-    });
+    await coreClient.updatePackageConfig(packageName, config);
   },
 };

--- a/packages/app/src/stores/packages.svelte.ts
+++ b/packages/app/src/stores/packages.svelte.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { coreClient } from "$lib/client";
 import type { Package } from "$lib/types";
 import type { OperationalState } from "$lib/types/operational_state";
 import { operationalStateStore } from "./operationalState.svelte";
@@ -93,7 +93,7 @@ export const packagesStore = {
     };
 
     try {
-      const result = await invoke<Record<string, Package>>("get_packages");
+      const result = await coreClient.getPackages();
       catalogState = {
         status: "ready",
         packages: result,
@@ -132,7 +132,7 @@ export const packagesStore = {
     };
 
     try {
-      const result = await invoke<Package[]>("get_installed_packages");
+      const result = await coreClient.getInstalledPackages();
 
       if (requestId !== installedRequestToken) {
         return;
@@ -163,7 +163,7 @@ export const packagesStore = {
 
   async installPackage(name: string) {
     try {
-      await invoke("install_package", { name });
+      await coreClient.installPackage(name);
       await this.loadInstalledPackages({ force: true });
     } catch (e) {
       console.error(`Failed to install ${name}: ${e}`);
@@ -173,10 +173,7 @@ export const packagesStore = {
 
   async deletePackage(name: string) {
     try {
-      await invoke("delete_package", {
-        name,
-        includeImages: false,
-      });
+      await coreClient.deletePackage(name, false);
       await this.loadInstalledPackages({ force: true });
     } catch (e) {
       console.error(`Failed to delete ${name}: ${e}`);

--- a/packages/app/src/stores/systemInfo.svelte.ts
+++ b/packages/app/src/stores/systemInfo.svelte.ts
@@ -1,5 +1,5 @@
+import { coreClient } from "$lib/client";
 import type { SystemInfo } from "$lib/types/system_info";
-import { invoke } from "@tauri-apps/api/core";
 
 let systemInfo = $state<SystemInfo>();
 
@@ -10,7 +10,7 @@ export const systemInfoStore = {
   async fetchSystemInfo() {
     try {
       systemInfo = undefined; // invalidate previous data
-      systemInfo = await invoke("system_info");
+      systemInfo = await coreClient.getSystemInfo();
       console.info("Successfully fetched system info.");
     } catch (e) {
       console.error(`Failed to fetch system info: ${e}.`);

--- a/packages/app/src/types/semver.d.ts
+++ b/packages/app/src/types/semver.d.ts
@@ -1,0 +1,8 @@
+declare module "semver" {
+  export function clean(version: string, options?: unknown): string | null;
+  export function gt(
+    version: string,
+    other: string,
+    options?: unknown,
+  ): boolean;
+}

--- a/packages/core/src/domain/config.rs
+++ b/packages/core/src/domain/config.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Config {
     pub capabilities: Vec<String>,
-    #[serde(alias = "serverUrl")]
     pub server_url: String,
-    #[serde(default, alias = "onboardingCompleted")]
+    #[serde(default)]
     pub onboarding_completed: bool,
-    #[serde(default, alias = "autoStartDocker")]
+    #[serde(default)]
     pub auto_start_docker: bool,
 }

--- a/packages/core/src/domain/config.rs
+++ b/packages/core/src/domain/config.rs
@@ -3,9 +3,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct Config {
     pub capabilities: Vec<String>,
+    #[serde(alias = "serverUrl")]
     pub server_url: String,
-    #[serde(default)]
+    #[serde(default, alias = "onboardingCompleted")]
     pub onboarding_completed: bool,
-    #[serde(default)]
+    #[serde(default, alias = "autoStartDocker")]
     pub auto_start_docker: bool,
 }

--- a/packages/core/src/domain/container.rs
+++ b/packages/core/src/domain/container.rs
@@ -1,9 +1,9 @@
-use bollard::models::PortBinding;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Container {
     pub(crate) name: String,
     pub(crate) image: String,
@@ -14,6 +14,14 @@ pub struct Container {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PortBinding {
+    pub(crate) host_ip: Option<String>,
+    pub(crate) host_port: Option<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Binding {
     pub(crate) source: String,
     pub(crate) destination: String,

--- a/packages/core/src/domain/operational_state.rs
+++ b/packages/core/src/domain/operational_state.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 pub enum OperationalMode {
     Local,
     Remote,

--- a/packages/core/src/domain/operational_state.rs
+++ b/packages/core/src/domain/operational_state.rs
@@ -10,8 +10,11 @@ pub enum OperationalMode {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OperationalState {
     pub mode: OperationalMode,
+    #[serde(alias = "dockerRunning")]
     pub docker_running: bool,
+    #[serde(alias = "canInstall")]
     pub can_install: bool,
+    #[serde(alias = "canManage")]
     pub can_manage: bool,
     pub diagnostics: Vec<String>,
 }

--- a/packages/core/src/domain/operational_state.rs
+++ b/packages/core/src/domain/operational_state.rs
@@ -8,13 +8,11 @@ pub enum OperationalMode {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OperationalState {
     pub mode: OperationalMode,
-    #[serde(alias = "dockerRunning")]
     pub docker_running: bool,
-    #[serde(alias = "canInstall")]
     pub can_install: bool,
-    #[serde(alias = "canManage")]
     pub can_manage: bool,
     pub diagnostics: Vec<String>,
 }

--- a/packages/core/src/domain/package.rs
+++ b/packages/core/src/domain/package.rs
@@ -10,6 +10,7 @@ pub(crate) trait PackageDefinition {
 }
 
 #[derive(Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct PackageConfig {
     pub values: HashMap<String, String>,
 }
@@ -24,6 +25,7 @@ impl PackageConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Package {
     pub(crate) name: String,
     pub(crate) description: String,

--- a/packages/core/src/domain/system_info.rs
+++ b/packages/core/src/domain/system_info.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SystemInfo {
     pub processor: ProcessorInfo,
     pub memory: MemoryInfo,
@@ -8,6 +9,7 @@ pub struct SystemInfo {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProcessorInfo {
     pub name: String,
     pub cores: u32,
@@ -16,17 +18,20 @@ pub struct ProcessorInfo {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MemoryInfo {
     pub total_bytes: u64,
     pub total_display: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StorageInfo {
     pub disks: Vec<DiskInfo>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DiskInfo {
     pub name: String,
     pub mount_point: String,

--- a/packages/core/src/manifests/ethereum.rs
+++ b/packages/core/src/manifests/ethereum.rs
@@ -1,9 +1,8 @@
-use bollard::models::PortBinding;
 use eyre::Result;
 use std::collections::HashMap;
 
 use crate::{
-    domain::container::{Binding, Container},
+    domain::container::{Binding, Container, PortBinding},
     domain::package::{Package, PackageConfig, PackageDefinition},
     infra::file::kittynode_path,
 };

--- a/website/src/routes/download/+page.svelte
+++ b/website/src/routes/download/+page.svelte
@@ -4,7 +4,7 @@ import {
   Monitor,
   Download,
   AppWindowMac,
-  CircleQuestionMark,
+  HelpCircle,
   ChevronDown,
 } from "@lucide/svelte";
 import { Button } from "$lib/components/ui/button/index.js";
@@ -133,7 +133,7 @@ let linuxHelpOpen = false;
 		<div class="overflow-hidden rounded-lg border">
 			<CollapsibleTrigger class="flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm font-medium transition-colors hover:bg-muted/60">
 				<span class="flex items-center gap-2">
-					<CircleQuestionMark class="h-4 w-4 text-link" />
+					<HelpCircle class="h-4 w-4 text-link" />
 					Looking for another Linux package format?
 				</span>
 				<ChevronDown class={`h-4 w-4 transition-transform ${linuxHelpOpen ? "rotate-180" : ""}`} />


### PR DESCRIPTION
## Summary
- add a shared Tauri client so Svelte stops invoking @tauri-apps/api/core directly
- deserialize core snake_case payloads into camelCase before the UI touches them
- enforce the new client usage via biome and add local semver types

## Testing
- just lint-js
- just lint-rs