### PR TITLE
Add validator key and deposit foundations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bollard"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,12 +2117,15 @@ dependencies = [
 name = "kittynode-core"
 version = "0.4.0"
 dependencies = [
+ "blst",
  "bollard",
  "eyre",
  "hex",
  "home",
  "rand 0.9.2",
  "serde",
+ "serde_json",
+ "sha2",
  "sysinfo",
  "tempfile",
  "tokio-stream",
@@ -2446,6 +2467,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4682,6 +4713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6074,6 +6114,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "zerotrie"

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -1,9 +1,11 @@
-use eyre::{Result, WrapErr};
-use kittynode_core::api;
+use eyre::{Result, WrapErr, eyre};
 use kittynode_core::api::types::{
     Config, OperationalMode, OperationalState, Package, PackageConfig, SystemInfo,
 };
+use kittynode_core::api::{self, CreateDepositDataParams, GenerateKeysParams};
 use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::path::PathBuf;
 
 pub async fn get_packages() -> Result<()> {
     let packages = api::get_packages()?;
@@ -216,4 +218,98 @@ fn print_operational_state_text(state: &OperationalState) {
             println!("  - {entry}");
         }
     }
+}
+
+pub fn validator_generate_keys(
+    output_dir: PathBuf,
+    file_name: Option<String>,
+    entropy: String,
+    overwrite: bool,
+) -> Result<()> {
+    let params = GenerateKeysParams {
+        output_dir,
+        file_name,
+        entropy,
+        overwrite,
+    };
+    let key_path = params.key_path();
+    let key = api::generate_keys(params)?;
+    println!("Stored validator key at {}", key_path.display());
+    println!("Public key: {}", key.public_key);
+    Ok(())
+}
+
+pub fn validator_create_deposit_data(
+    key_path: PathBuf,
+    output_path: PathBuf,
+    withdrawal_credentials: String,
+    amount_gwei: u64,
+    fork_version_hex: String,
+    genesis_root_hex: String,
+    overwrite: bool,
+) -> Result<()> {
+    let fork_version = parse_fork_version(&fork_version_hex)?;
+    let genesis_root_bytes = parse_hex_32(&genesis_root_hex)?;
+    let genesis_root = canonicalize_hex(&genesis_root_bytes);
+    let params = CreateDepositDataParams {
+        key_path,
+        output_path: output_path.clone(),
+        withdrawal_credentials,
+        amount_gwei,
+        fork_version,
+        genesis_validators_root: genesis_root,
+        overwrite,
+    };
+
+    let deposit = api::create_deposit_data(params)?;
+    println!("Stored deposit data at {}", output_path.display());
+    println!("Deposit data root: {}", deposit.deposit_data_root);
+    Ok(())
+}
+
+fn parse_fork_version(input: &str) -> Result<[u8; 4]> {
+    let trimmed = input.trim().trim_start_matches("0x");
+    if trimmed.len() != 8 {
+        return Err(eyre!(
+            "fork version must be 4 bytes (8 hex characters), received {}",
+            input
+        ));
+    }
+
+    let mut bytes = [0u8; 4];
+    for (idx, chunk) in trimmed.as_bytes().chunks(2).enumerate() {
+        let hex = std::str::from_utf8(chunk).map_err(|_| eyre!("invalid UTF-8 in fork version"))?;
+        bytes[idx] =
+            u8::from_str_radix(hex, 16).map_err(|_| eyre!("invalid hex in fork version: {hex}"))?;
+    }
+    Ok(bytes)
+}
+
+fn parse_hex_32(input: &str) -> Result<[u8; 32]> {
+    let trimmed = input.trim();
+    let without_prefix = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+    if without_prefix.len() != 64 {
+        return Err(eyre!(
+            "genesis validators root must be 32 bytes (64 hex characters), received {}",
+            input
+        ));
+    }
+
+    let mut bytes = [0u8; 32];
+    for (idx, chunk) in without_prefix.as_bytes().chunks(2).enumerate() {
+        let hex = std::str::from_utf8(chunk)
+            .map_err(|_| eyre!("invalid UTF-8 in genesis validators root"))?;
+        bytes[idx] = u8::from_str_radix(hex, 16)
+            .map_err(|_| eyre!("invalid hex in genesis validators root: {hex}"))?;
+    }
+    Ok(bytes)
+}
+
+fn canonicalize_hex(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(2 + bytes.len() * 2);
+    output.push_str("0x");
+    for byte in bytes {
+        write!(&mut output, "{:02x}", byte).expect("write to string");
+    }
+    output
 }

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -14,6 +14,7 @@ eyre = { version = "0.6.12", default-features = false, features = [
   "track-caller",
 ] }
 serde = { version = "1.0.223", features = ["derive"] }
+serde_json = "1.0.132"
 toml = "0.9.5"
 tracing = "0.1.41"
 tokio-stream = "0.1.17"
@@ -21,6 +22,6 @@ home = "0.5.11"
 hex = "0.4.3"
 rand = "0.9.2"
 sysinfo = "0.37.0"
-
-[dev-dependencies]
+sha2 = "0.10.8"
 tempfile = "3.22.0"
+blst = "0.3.15"

--- a/packages/core/src/api/mod.rs
+++ b/packages/core/src/api/mod.rs
@@ -22,5 +22,8 @@ pub use crate::application::set_server_url;
 pub use crate::application::start_docker;
 pub use crate::application::start_docker_if_needed;
 pub use crate::application::update_package_config;
+pub use crate::application::validator::{
+    CreateDepositDataParams, GenerateKeysParams, create_deposit_data, generate_keys,
+};
 
 pub mod types;

--- a/packages/core/src/api/types.rs
+++ b/packages/core/src/api/types.rs
@@ -3,3 +3,4 @@ pub use crate::domain::logs::LogsQuery;
 pub use crate::domain::operational_state::{OperationalMode, OperationalState};
 pub use crate::domain::package::{Package, PackageConfig};
 pub use crate::domain::system_info::SystemInfo;
+pub use crate::domain::validator::{DepositData, ValidatorKey};

--- a/packages/core/src/application/mod.rs
+++ b/packages/core/src/application/mod.rs
@@ -21,6 +21,7 @@ pub mod set_server_url;
 pub mod start_docker;
 pub mod start_docker_if_needed;
 pub mod update_package_config;
+pub mod validator;
 
 pub use add_capability::add_capability;
 pub use delete_kittynode::delete_kittynode;

--- a/packages/core/src/application/validator/create_deposit_data.rs
+++ b/packages/core/src/application/validator/create_deposit_data.rs
@@ -37,8 +37,8 @@ impl CreateDepositDataParams {
 }
 
 pub fn create_deposit_data(params: CreateDepositDataParams) -> Result<DepositData> {
-    let crypto = SimpleCryptoProvider::default();
-    let filesystem = StdValidatorFilesystem::default();
+    let crypto = SimpleCryptoProvider;
+    let filesystem = StdValidatorFilesystem;
     create_deposit_data_with(params, &crypto, &filesystem)
 }
 
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn builds_deposit_and_writes_file() {
         let fs = TestFilesystem::default();
-        let crypto = TestCrypto::default();
+        let crypto = TestCrypto;
         let key_path = PathBuf::from("/validators/key.json");
         let deposit_path = PathBuf::from("/validators/deposit.json");
 
@@ -214,7 +214,7 @@ mod tests {
     #[test]
     fn rejects_insecure_key_file() {
         let fs = TestFilesystem::default();
-        let crypto = TestCrypto::default();
+        let crypto = TestCrypto;
         let key_path = PathBuf::from("/validators/key.json");
         fs.insecure_files
             .lock()

--- a/packages/core/src/application/validator/create_deposit_data.rs
+++ b/packages/core/src/application/validator/create_deposit_data.rs
@@ -1,0 +1,279 @@
+use super::ports::{CryptoProvider, ValidatorFilesystem};
+use crate::domain::validator::DepositData;
+use crate::infra::validator::{SimpleCryptoProvider, StdValidatorFilesystem};
+use eyre::{Context, Result};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct CreateDepositDataParams {
+    pub key_path: PathBuf,
+    pub output_path: PathBuf,
+    pub withdrawal_credentials: String,
+    pub amount_gwei: u64,
+    pub fork_version: [u8; 4],
+    pub genesis_validators_root: String,
+    pub overwrite: bool,
+}
+
+impl CreateDepositDataParams {
+    pub fn new(
+        key_path: PathBuf,
+        output_path: PathBuf,
+        withdrawal_credentials: String,
+        amount_gwei: u64,
+        fork_version: [u8; 4],
+        genesis_validators_root: String,
+    ) -> Self {
+        Self {
+            key_path,
+            output_path,
+            withdrawal_credentials,
+            amount_gwei,
+            fork_version,
+            genesis_validators_root,
+            overwrite: false,
+        }
+    }
+}
+
+pub fn create_deposit_data(params: CreateDepositDataParams) -> Result<DepositData> {
+    let crypto = SimpleCryptoProvider::default();
+    let filesystem = StdValidatorFilesystem::default();
+    create_deposit_data_with(params, &crypto, &filesystem)
+}
+
+pub fn create_deposit_data_with<P, F>(
+    params: CreateDepositDataParams,
+    crypto: &P,
+    filesystem: &F,
+) -> Result<DepositData>
+where
+    P: CryptoProvider,
+    F: ValidatorFilesystem,
+{
+    let key = filesystem
+        .read_json_secure(&params.key_path)
+        .with_context(|| {
+            format!(
+                "failed to read validator key from {}",
+                params.key_path.display()
+            )
+        })?;
+
+    if let Some(parent) = params.output_path.parent() {
+        filesystem
+            .ensure_secure_directory(parent)
+            .with_context(|| {
+                format!("invalid validator artifact directory: {}", parent.display())
+            })?;
+    }
+
+    let deposit = crypto
+        .create_deposit_data(
+            &key,
+            &params.withdrawal_credentials,
+            params.amount_gwei,
+            params.fork_version,
+            &params.genesis_validators_root,
+        )
+        .context("failed to build deposit data")?;
+
+    filesystem
+        .write_json_secure(&params.output_path, &deposit, params.overwrite)
+        .context("failed to write deposit data")?;
+
+    Ok(deposit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::validator::ports::{CryptoProvider, ValidatorFilesystem};
+    use crate::application::validator::{GenerateKeysParams, generate_keys};
+    use crate::domain::validator::{DepositData, ValidatorKey};
+    use eyre::Result;
+    use serde::{Serialize, de::DeserializeOwned};
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    #[derive(Default)]
+    struct TestFilesystem {
+        files: Mutex<HashMap<PathBuf, String>>,
+        insecure_dirs: Mutex<Vec<PathBuf>>,
+        insecure_files: Mutex<Vec<PathBuf>>,
+    }
+
+    impl ValidatorFilesystem for TestFilesystem {
+        fn ensure_secure_directory(&self, path: &Path) -> Result<()> {
+            if self
+                .insecure_dirs
+                .lock()
+                .expect("mutex poisoned")
+                .iter()
+                .any(|p| p == path)
+            {
+                eyre::bail!("directory has insecure permissions: {}", path.display());
+            }
+            Ok(())
+        }
+
+        fn write_json_secure<T: Serialize>(
+            &self,
+            path: &Path,
+            value: &T,
+            _overwrite: bool,
+        ) -> Result<()> {
+            let json = serde_json::to_string(value)?;
+            self.files
+                .lock()
+                .expect("mutex poisoned")
+                .insert(path.to_path_buf(), json);
+            Ok(())
+        }
+
+        fn read_json_secure<T: DeserializeOwned>(&self, path: &Path) -> Result<T> {
+            if self
+                .insecure_files
+                .lock()
+                .expect("mutex poisoned")
+                .iter()
+                .any(|p| p == path)
+            {
+                eyre::bail!("insecure file permissions: {}", path.display());
+            }
+            let files = self.files.lock().expect("mutex poisoned");
+            let contents = files
+                .get(path)
+                .ok_or_else(|| eyre::eyre!("missing file: {}", path.display()))?;
+            Ok(serde_json::from_str(contents)?)
+        }
+    }
+
+    #[derive(Default)]
+    struct TestCrypto;
+
+    impl CryptoProvider for TestCrypto {
+        fn generate_key(&self, _entropy: &str) -> Result<ValidatorKey> {
+            unreachable!("not used in create_deposit_data tests")
+        }
+
+        fn create_deposit_data(
+            &self,
+            key: &ValidatorKey,
+            withdrawal_credentials: &str,
+            amount_gwei: u64,
+            _fork_version: [u8; 4],
+            _genesis_validators_root: &str,
+        ) -> Result<DepositData> {
+            Ok(DepositData {
+                public_key: key.public_key.clone(),
+                withdrawal_credentials: withdrawal_credentials.to_string(),
+                amount_gwei,
+                signature: "sig".into(),
+                deposit_message_root: "msg_root".into(),
+                deposit_data_root: "data_root".into(),
+                fork_version: "0x00000000".into(),
+            })
+        }
+    }
+
+    #[test]
+    fn builds_deposit_and_writes_file() {
+        let fs = TestFilesystem::default();
+        let crypto = TestCrypto::default();
+        let key_path = PathBuf::from("/validators/key.json");
+        let deposit_path = PathBuf::from("/validators/deposit.json");
+
+        let key = ValidatorKey {
+            public_key: "pub".into(),
+            secret_key: "sec".into(),
+        };
+        fs.write_json_secure(&key_path, &key, true).unwrap();
+
+        let params = CreateDepositDataParams {
+            key_path: key_path.clone(),
+            output_path: deposit_path.clone(),
+            withdrawal_credentials: "cred".into(),
+            amount_gwei: 32_000_000_000,
+            fork_version: [0, 0, 0, 0],
+            genesis_validators_root:
+                "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".into(),
+            overwrite: false,
+        };
+
+        let deposit = create_deposit_data_with(params, &crypto, &fs).unwrap();
+        assert_eq!(deposit.public_key, "pub");
+
+        let stored: DepositData = fs.read_json_secure(&deposit_path).unwrap();
+        assert_eq!(stored.signature, "sig");
+    }
+
+    #[test]
+    fn rejects_insecure_key_file() {
+        let fs = TestFilesystem::default();
+        let crypto = TestCrypto::default();
+        let key_path = PathBuf::from("/validators/key.json");
+        fs.insecure_files
+            .lock()
+            .expect("mutex poisoned")
+            .push(key_path.clone());
+
+        let params = CreateDepositDataParams {
+            key_path: key_path.clone(),
+            output_path: PathBuf::from("/validators/deposit.json"),
+            withdrawal_credentials: "cred".into(),
+            amount_gwei: 32_000_000_000,
+            fork_version: [0, 0, 0, 0],
+            genesis_validators_root:
+                "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".into(),
+            overwrite: false,
+        };
+
+        let result = create_deposit_data_with(params, &crypto, &fs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn default_flow_writes_to_disk() {
+        let dir = tempdir().unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(dir.path()).unwrap().permissions();
+            perms.set_mode(0o700);
+            fs::set_permissions(dir.path(), perms).unwrap();
+        }
+        let key_params = GenerateKeysParams {
+            output_dir: dir.path().to_path_buf(),
+            file_name: Some("validator_key.json".into()),
+            entropy: "kitty".into(),
+            overwrite: true,
+        };
+        let key_path = key_params.key_path();
+        generate_keys(key_params).unwrap();
+
+        let deposit_path = dir.path().join("deposit_data.json");
+        let params = CreateDepositDataParams {
+            key_path: key_path.clone(),
+            output_path: deposit_path.clone(),
+            withdrawal_credentials:
+                "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".into(),
+            amount_gwei: 32_000_000_000,
+            fork_version: [0, 0, 0, 0],
+            genesis_validators_root:
+                "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".into(),
+            overwrite: true,
+        };
+
+        let deposit = create_deposit_data(params).unwrap();
+        let decoded: DepositData =
+            serde_json::from_slice(&fs::read(&deposit_path).unwrap()).unwrap();
+        assert_eq!(deposit, decoded);
+        assert_eq!(deposit.public_key.len(), 98);
+        assert_eq!(deposit.signature.len(), 194);
+        assert_eq!(deposit.deposit_data_root.len(), 66);
+    }
+}

--- a/packages/core/src/application/validator/create_deposit_data.rs
+++ b/packages/core/src/application/validator/create_deposit_data.rs
@@ -1,4 +1,7 @@
 use super::ports::{CryptoProvider, ValidatorFilesystem};
+use crate::application::validator::input::{
+    parse_fork_version_hex, parse_genesis_validators_root_hex,
+};
 use crate::domain::validator::DepositData;
 use crate::infra::validator::{SimpleCryptoProvider, StdValidatorFilesystem};
 use eyre::{Context, Result};
@@ -16,23 +19,26 @@ pub struct CreateDepositDataParams {
 }
 
 impl CreateDepositDataParams {
-    pub fn new(
+    pub fn from_hex_inputs(
         key_path: PathBuf,
         output_path: PathBuf,
         withdrawal_credentials: String,
         amount_gwei: u64,
-        fork_version: [u8; 4],
-        genesis_validators_root: String,
-    ) -> Self {
-        Self {
+        fork_version_hex: &str,
+        genesis_root_hex: &str,
+        overwrite: bool,
+    ) -> Result<Self> {
+        let fork_version = parse_fork_version_hex(fork_version_hex)?;
+        let genesis_validators_root = parse_genesis_validators_root_hex(genesis_root_hex)?;
+        Ok(Self {
             key_path,
             output_path,
             withdrawal_credentials,
             amount_gwei,
             fork_version,
             genesis_validators_root,
-            overwrite: false,
-        }
+            overwrite,
+        })
     }
 }
 

--- a/packages/core/src/application/validator/generate_keys.rs
+++ b/packages/core/src/application/validator/generate_keys.rs
@@ -45,8 +45,8 @@ impl Default for GenerateKeysParams {
 }
 
 pub fn generate_keys(params: GenerateKeysParams) -> Result<ValidatorKey> {
-    let crypto = SimpleCryptoProvider::default();
-    let filesystem = StdValidatorFilesystem::default();
+    let crypto = SimpleCryptoProvider;
+    let filesystem = StdValidatorFilesystem;
     generate_keys_with(params, &crypto, &filesystem)
 }
 
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     fn writes_key_using_filesystem() {
         let fs = TestFilesystem::default();
-        let crypto = TestCrypto::default();
+        let crypto = TestCrypto;
         let params = GenerateKeysParams {
             output_dir: PathBuf::from("/validators"),
             file_name: Some("key.json".into()),
@@ -194,7 +194,7 @@ mod tests {
             .lock()
             .expect("mutex poisoned")
             .push(PathBuf::from("/validators"));
-        let crypto = TestCrypto::default();
+        let crypto = TestCrypto;
         let params = GenerateKeysParams {
             output_dir: PathBuf::from("/validators"),
             file_name: Some("key.json".into()),

--- a/packages/core/src/application/validator/generate_keys.rs
+++ b/packages/core/src/application/validator/generate_keys.rs
@@ -1,0 +1,227 @@
+use super::ports::{CryptoProvider, ValidatorFilesystem};
+use crate::domain::validator::ValidatorKey;
+use crate::infra::validator::{SimpleCryptoProvider, StdValidatorFilesystem};
+use eyre::{Context, Result};
+use std::path::{Path, PathBuf};
+
+const DEFAULT_KEY_FILENAME: &str = "validator_key.json";
+
+#[derive(Debug, Clone)]
+pub struct GenerateKeysParams {
+    pub output_dir: PathBuf,
+    pub file_name: Option<String>,
+    pub entropy: String,
+    pub overwrite: bool,
+}
+
+impl GenerateKeysParams {
+    pub fn new(output_dir: PathBuf, entropy: String) -> Self {
+        Self {
+            output_dir,
+            file_name: None,
+            entropy,
+            overwrite: false,
+        }
+    }
+
+    pub fn key_path(&self) -> PathBuf {
+        self.output_dir.join(self.file_name())
+    }
+
+    fn file_name(&self) -> &str {
+        self.file_name.as_deref().unwrap_or(DEFAULT_KEY_FILENAME)
+    }
+}
+
+impl Default for GenerateKeysParams {
+    fn default() -> Self {
+        Self {
+            output_dir: PathBuf::new(),
+            file_name: None,
+            entropy: String::new(),
+            overwrite: false,
+        }
+    }
+}
+
+pub fn generate_keys(params: GenerateKeysParams) -> Result<ValidatorKey> {
+    let crypto = SimpleCryptoProvider::default();
+    let filesystem = StdValidatorFilesystem::default();
+    generate_keys_with(params, &crypto, &filesystem)
+}
+
+pub fn generate_keys_with<P, F>(
+    params: GenerateKeysParams,
+    crypto: &P,
+    filesystem: &F,
+) -> Result<ValidatorKey>
+where
+    P: CryptoProvider,
+    F: ValidatorFilesystem,
+{
+    let key_file = params.key_path();
+    ensure_parent_secure(&key_file, filesystem)?;
+
+    let key = crypto
+        .generate_key(&params.entropy)
+        .context("failed to generate validator key")?;
+
+    filesystem
+        .write_json_secure(&key_file, &key, params.overwrite)
+        .context("failed to write validator key")?;
+
+    Ok(key)
+}
+
+fn ensure_parent_secure<F: ValidatorFilesystem>(path: &Path, filesystem: &F) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        filesystem
+            .ensure_secure_directory(parent)
+            .with_context(|| format!("invalid validator output directory: {}", parent.display()))?
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::validator::ports::{CryptoProvider, ValidatorFilesystem};
+    use crate::domain::validator::ValidatorKey;
+    use eyre::Result;
+    use serde::{Serialize, de::DeserializeOwned};
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    #[derive(Default)]
+    struct TestFilesystem {
+        files: Mutex<HashMap<PathBuf, String>>,
+        insecure_dirs: Mutex<Vec<PathBuf>>,
+    }
+
+    impl ValidatorFilesystem for TestFilesystem {
+        fn ensure_secure_directory(&self, path: &Path) -> Result<()> {
+            if self
+                .insecure_dirs
+                .lock()
+                .expect("mutex poisoned")
+                .iter()
+                .any(|p| p == path)
+            {
+                eyre::bail!("directory has insecure permissions: {}", path.display());
+            }
+            Ok(())
+        }
+
+        fn write_json_secure<T: Serialize>(
+            &self,
+            path: &Path,
+            value: &T,
+            _overwrite: bool,
+        ) -> Result<()> {
+            let json = serde_json::to_string(value)?;
+            self.files
+                .lock()
+                .expect("mutex poisoned")
+                .insert(path.to_path_buf(), json);
+            Ok(())
+        }
+
+        fn read_json_secure<T: DeserializeOwned>(&self, path: &Path) -> Result<T> {
+            let files = self.files.lock().expect("mutex poisoned");
+            let contents = files
+                .get(path)
+                .ok_or_else(|| eyre::eyre!("missing file: {}", path.display()))?;
+            Ok(serde_json::from_str(contents)?)
+        }
+    }
+
+    #[derive(Default)]
+    struct TestCrypto;
+
+    impl CryptoProvider for TestCrypto {
+        fn generate_key(&self, entropy: &str) -> Result<ValidatorKey> {
+            Ok(ValidatorKey {
+                public_key: format!("pub-{entropy}"),
+                secret_key: format!("sec-{entropy}"),
+            })
+        }
+
+        fn create_deposit_data(
+            &self,
+            _key: &ValidatorKey,
+            _withdrawal_credentials: &str,
+            _amount_gwei: u64,
+            _fork_version: [u8; 4],
+            _genesis_validators_root: &str,
+        ) -> Result<crate::domain::validator::DepositData> {
+            unreachable!("not used in generate_keys tests")
+        }
+    }
+
+    #[test]
+    fn writes_key_using_filesystem() {
+        let fs = TestFilesystem::default();
+        let crypto = TestCrypto::default();
+        let params = GenerateKeysParams {
+            output_dir: PathBuf::from("/validators"),
+            file_name: Some("key.json".into()),
+            entropy: "seed".into(),
+            overwrite: false,
+        };
+
+        let key = generate_keys_with(params.clone(), &crypto, &fs).unwrap();
+        assert_eq!(
+            key,
+            ValidatorKey {
+                public_key: "pub-seed".into(),
+                secret_key: "sec-seed".into(),
+            }
+        );
+
+        let stored: ValidatorKey = fs
+            .read_json_secure(&PathBuf::from("/validators/key.json"))
+            .unwrap();
+        assert_eq!(stored, key);
+    }
+
+    #[test]
+    fn rejects_insecure_directory() {
+        let fs = TestFilesystem::default();
+        fs.insecure_dirs
+            .lock()
+            .expect("mutex poisoned")
+            .push(PathBuf::from("/validators"));
+        let crypto = TestCrypto::default();
+        let params = GenerateKeysParams {
+            output_dir: PathBuf::from("/validators"),
+            file_name: Some("key.json".into()),
+            entropy: "seed".into(),
+            overwrite: false,
+        };
+
+        let result = generate_keys_with(params, &crypto, &fs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn default_flow_creates_real_files() {
+        let dir = tempdir().unwrap();
+        let output_dir = dir.path().join("validators");
+        let params = GenerateKeysParams {
+            output_dir: output_dir.clone(),
+            file_name: None,
+            entropy: "kitty".into(),
+            overwrite: true,
+        };
+
+        let key = generate_keys(params).unwrap();
+        let written = fs::read_to_string(output_dir.join(DEFAULT_KEY_FILENAME)).unwrap();
+        let decoded: ValidatorKey = serde_json::from_str(&written).unwrap();
+        assert_eq!(decoded, key);
+        assert_eq!(key.public_key.len(), 98);
+        assert_eq!(key.secret_key.len(), 66);
+    }
+}

--- a/packages/core/src/application/validator/input.rs
+++ b/packages/core/src/application/validator/input.rs
@@ -1,0 +1,71 @@
+use eyre::{Result, eyre};
+
+pub(crate) fn parse_fork_version_hex(input: &str) -> Result<[u8; 4]> {
+    let trimmed = input.trim().trim_start_matches("0x");
+    if trimmed.len() != 8 {
+        return Err(eyre!(
+            "fork version must be 4 bytes (8 hex characters), received {}",
+            input
+        ));
+    }
+
+    let mut bytes = [0u8; 4];
+    for (idx, chunk) in trimmed.as_bytes().chunks(2).enumerate() {
+        let hex = std::str::from_utf8(chunk).map_err(|_| eyre!("invalid UTF-8 in fork version"))?;
+        bytes[idx] =
+            u8::from_str_radix(hex, 16).map_err(|_| eyre!("invalid hex in fork version: {hex}"))?;
+    }
+    Ok(bytes)
+}
+
+pub(crate) fn parse_genesis_validators_root_hex(input: &str) -> Result<String> {
+    let trimmed = input.trim();
+    let without_prefix = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+    if without_prefix.len() != 64 {
+        return Err(eyre!(
+            "genesis validators root must be 32 bytes (64 hex characters), received {}",
+            input
+        ));
+    }
+
+    let mut bytes = [0u8; 32];
+    for (idx, chunk) in without_prefix.as_bytes().chunks(2).enumerate() {
+        let hex = std::str::from_utf8(chunk)
+            .map_err(|_| eyre!("invalid UTF-8 in genesis validators root"))?;
+        bytes[idx] = u8::from_str_radix(hex, 16)
+            .map_err(|_| eyre!("invalid hex in genesis validators root: {hex}"))?;
+    }
+
+    let mut output = String::with_capacity(66);
+    output.push_str("0x");
+    for byte in &bytes {
+        use std::fmt::Write;
+        write!(&mut output, "{:02x}", byte).expect("write to string");
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_fork_version() {
+        let result = parse_fork_version_hex("0x01020304").unwrap();
+        assert_eq!(result, [0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn rejects_invalid_fork_version_length() {
+        let err = parse_fork_version_hex("0x01").unwrap_err();
+        assert!(err.to_string().contains("8 hex characters"));
+    }
+
+    #[test]
+    fn parses_genesis_root_and_canonicalizes_prefix() {
+        let input = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        let output = parse_genesis_validators_root_hex(input).unwrap();
+        assert!(output.starts_with("0x"));
+        assert_eq!(output.len(), 66);
+    }
+}

--- a/packages/core/src/application/validator/mod.rs
+++ b/packages/core/src/application/validator/mod.rs
@@ -1,0 +1,6 @@
+mod create_deposit_data;
+mod generate_keys;
+pub mod ports;
+
+pub use create_deposit_data::{CreateDepositDataParams, create_deposit_data};
+pub use generate_keys::{GenerateKeysParams, generate_keys};

--- a/packages/core/src/application/validator/mod.rs
+++ b/packages/core/src/application/validator/mod.rs
@@ -1,5 +1,6 @@
 mod create_deposit_data;
 mod generate_keys;
+mod input;
 pub mod ports;
 
 pub use create_deposit_data::{CreateDepositDataParams, create_deposit_data};

--- a/packages/core/src/application/validator/ports.rs
+++ b/packages/core/src/application/validator/ports.rs
@@ -1,0 +1,29 @@
+use crate::domain::validator::{DepositData, ValidatorKey};
+use eyre::Result;
+use serde::{Serialize, de::DeserializeOwned};
+use std::path::Path;
+
+/// Provides cryptographic operations required by the validator slice.
+pub trait CryptoProvider: Send + Sync {
+    fn generate_key(&self, entropy: &str) -> Result<ValidatorKey>;
+    fn create_deposit_data(
+        &self,
+        key: &ValidatorKey,
+        withdrawal_credentials: &str,
+        amount_gwei: u64,
+        fork_version: [u8; 4],
+        genesis_validators_root: &str,
+    ) -> Result<DepositData>;
+}
+
+/// Filesystem operations needed for persisting validator artifacts.
+pub trait ValidatorFilesystem: Send + Sync {
+    fn ensure_secure_directory(&self, path: &Path) -> Result<()>;
+    fn write_json_secure<T: Serialize>(
+        &self,
+        path: &Path,
+        value: &T,
+        overwrite: bool,
+    ) -> Result<()>;
+    fn read_json_secure<T: DeserializeOwned>(&self, path: &Path) -> Result<T>;
+}

--- a/packages/core/src/domain/mod.rs
+++ b/packages/core/src/domain/mod.rs
@@ -4,3 +4,4 @@ pub mod logs;
 pub mod operational_state;
 pub mod package;
 pub mod system_info;
+pub mod validator;

--- a/packages/core/src/domain/validator.rs
+++ b/packages/core/src/domain/validator.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+/// Represents a validator key pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidatorKey {
+    pub public_key: String,
+    pub secret_key: String,
+}
+
+/// Deposit data payload used for validator activation on the beacon chain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DepositData {
+    pub public_key: String,
+    pub withdrawal_credentials: String,
+    pub amount_gwei: u64,
+    pub signature: String,
+    pub deposit_message_root: String,
+    pub deposit_data_root: String,
+    pub fork_version: String,
+}

--- a/packages/core/src/infra/mod.rs
+++ b/packages/core/src/infra/mod.rs
@@ -3,3 +3,4 @@ pub mod docker;
 pub mod file;
 pub mod package;
 pub mod package_config;
+pub mod validator;

--- a/packages/core/src/infra/validator.rs
+++ b/packages/core/src/infra/validator.rs
@@ -1,0 +1,424 @@
+use crate::application::validator::ports::{CryptoProvider, ValidatorFilesystem};
+use crate::domain::validator::{DepositData, ValidatorKey};
+use blst::min_pk::SecretKey;
+use eyre::{Context, Result, eyre};
+use sha2::{Digest, Sha256};
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
+
+const DOMAIN_DEPOSIT: [u8; 4] = [0x03, 0x00, 0x00, 0x00];
+const BLS_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+type Root = [u8; 32];
+const ZERO_ROOT: Root = [0u8; 32];
+
+#[derive(Default)]
+pub struct SimpleCryptoProvider;
+
+impl CryptoProvider for SimpleCryptoProvider {
+    fn generate_key(&self, entropy: &str) -> Result<ValidatorKey> {
+        let secret = derive_secret_key(entropy)?;
+        let public = secret.sk_to_pk();
+
+        Ok(ValidatorKey {
+            public_key: encode_hex(&public.to_bytes()),
+            secret_key: encode_hex(&secret.to_bytes()),
+        })
+    }
+
+    fn create_deposit_data(
+        &self,
+        key: &ValidatorKey,
+        withdrawal_credentials: &str,
+        amount_gwei: u64,
+        fork_version: [u8; 4],
+        genesis_validators_root: &str,
+    ) -> Result<DepositData> {
+        let secret_bytes = decode_hex_fixed::<32>(&key.secret_key)?;
+        let secret = SecretKey::from_bytes(&secret_bytes)
+            .map_err(|_| eyre!("invalid validator secret key"))?;
+
+        let public_bytes = secret.sk_to_pk().to_bytes();
+        let public_hex = encode_hex(&public_bytes);
+
+        if !key.public_key.is_empty() {
+            let stored_pub = decode_hex(&key.public_key)?;
+            if stored_pub != public_bytes {
+                return Err(eyre!("validator public key does not match secret key"));
+            }
+        }
+
+        let withdrawal_bytes = decode_hex_fixed::<32>(withdrawal_credentials)?;
+        let genesis_root_bytes = decode_hex_fixed::<32>(genesis_validators_root)?;
+        let domain = compute_deposit_domain(fork_version, &genesis_root_bytes);
+        let deposit_message_root =
+            compute_deposit_message_root(&public_bytes, &withdrawal_bytes, amount_gwei);
+        let signing_root = compute_signing_root(&deposit_message_root, &domain);
+        let signature = secret.sign(signing_root.as_ref(), BLS_DST, &[]);
+        let signature_bytes = signature.to_bytes();
+        let deposit_data_root = compute_deposit_data_root(
+            &public_bytes,
+            &withdrawal_bytes,
+            amount_gwei,
+            &signature_bytes,
+        );
+
+        Ok(DepositData {
+            public_key: public_hex,
+            withdrawal_credentials: encode_hex(&withdrawal_bytes),
+            amount_gwei,
+            signature: encode_hex(&signature_bytes),
+            deposit_message_root: encode_hex(&deposit_message_root),
+            deposit_data_root: encode_hex(&deposit_data_root),
+            fork_version: encode_hex(&fork_version),
+        })
+    }
+}
+
+fn derive_secret_key(entropy: &str) -> Result<SecretKey> {
+    let mut hasher = Sha256::new();
+    hasher.update(entropy.as_bytes());
+    let seed: [u8; 32] = hasher.finalize().into();
+    SecretKey::key_gen(&seed, &[]).map_err(|_| eyre!("failed to derive validator secret key"))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    format!("0x{}", hex::encode(bytes))
+}
+
+fn decode_hex(input: &str) -> Result<Vec<u8>> {
+    let trimmed = input.trim();
+    let without_prefix = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+    if without_prefix.len() % 2 != 0 {
+        return Err(eyre!("hex value must have an even length"));
+    }
+    hex::decode(without_prefix).map_err(|err| eyre!("invalid hex: {err}"))
+}
+
+fn decode_hex_fixed<const N: usize>(input: &str) -> Result<[u8; N]> {
+    let bytes = decode_hex(input)?;
+    if bytes.len() != N {
+        return Err(eyre!("expected {N} bytes, found {}", bytes.len()));
+    }
+    let mut array = [0u8; N];
+    array.copy_from_slice(&bytes);
+    Ok(array)
+}
+
+fn compute_deposit_domain(fork_version: [u8; 4], genesis_validators_root: &[u8; 32]) -> Root {
+    let mut current_version_chunk = [0u8; 32];
+    current_version_chunk[..4].copy_from_slice(&fork_version);
+    let fork_data_root = merkleize(&[current_version_chunk, *genesis_validators_root]);
+
+    let mut domain = [0u8; 32];
+    domain[..4].copy_from_slice(&DOMAIN_DEPOSIT);
+    domain[4..].copy_from_slice(&fork_data_root[..28]);
+    domain
+}
+
+fn compute_deposit_message_root(
+    pubkey: &[u8; 48],
+    withdrawal_credentials: &[u8; 32],
+    amount_gwei: u64,
+) -> Root {
+    let pubkey_root = merkleize(&pack_bytes(pubkey));
+    let withdrawal_root = chunk_bytes32(withdrawal_credentials);
+    let amount_root = uint64_chunk(amount_gwei);
+    merkleize(&[pubkey_root, withdrawal_root, amount_root])
+}
+
+fn compute_deposit_data_root(
+    pubkey: &[u8; 48],
+    withdrawal_credentials: &[u8; 32],
+    amount_gwei: u64,
+    signature: &[u8; 96],
+) -> Root {
+    let pubkey_root = merkleize(&pack_bytes(pubkey));
+    let withdrawal_root = chunk_bytes32(withdrawal_credentials);
+    let amount_root = uint64_chunk(amount_gwei);
+    let signature_root = merkleize(&pack_bytes(signature));
+    merkleize(&[pubkey_root, withdrawal_root, amount_root, signature_root])
+}
+
+fn compute_signing_root(object_root: &Root, domain: &Root) -> Root {
+    merkleize(&[*object_root, *domain])
+}
+
+fn merkleize(chunks: &[Root]) -> Root {
+    if chunks.is_empty() {
+        return ZERO_ROOT;
+    }
+
+    let mut layer: Vec<Root> = chunks.to_vec();
+    let target_len = next_power_of_two(layer.len());
+    layer.resize(target_len, ZERO_ROOT);
+
+    while layer.len() > 1 {
+        let mut next_layer = Vec::with_capacity(layer.len() / 2);
+        for pair in layer.chunks(2) {
+            let left = pair[0];
+            let right = pair[1];
+            next_layer.push(hash_pair(&left, &right));
+        }
+        layer = next_layer;
+    }
+
+    layer[0]
+}
+
+fn hash_pair(left: &Root, right: &Root) -> Root {
+    let mut hasher = Sha256::new();
+    hasher.update(left);
+    hasher.update(right);
+    hasher.finalize().into()
+}
+
+fn pack_bytes(bytes: &[u8]) -> Vec<Root> {
+    if bytes.is_empty() {
+        return vec![ZERO_ROOT];
+    }
+
+    let mut chunks = Vec::new();
+    for chunk in bytes.chunks(32) {
+        let mut root = [0u8; 32];
+        root[..chunk.len()].copy_from_slice(chunk);
+        chunks.push(root);
+    }
+    chunks
+}
+
+fn chunk_bytes32(bytes: &[u8; 32]) -> Root {
+    *bytes
+}
+
+fn uint64_chunk(value: u64) -> Root {
+    let mut chunk = [0u8; 32];
+    chunk[..8].copy_from_slice(&value.to_le_bytes());
+    chunk
+}
+
+fn next_power_of_two(value: usize) -> usize {
+    if value == 0 {
+        1
+    } else {
+        value.next_power_of_two()
+    }
+}
+
+#[derive(Default)]
+pub struct StdValidatorFilesystem;
+
+impl ValidatorFilesystem for StdValidatorFilesystem {
+    fn ensure_secure_directory(&self, path: &Path) -> Result<()> {
+        if path.exists() {
+            let metadata = fs::metadata(path).wrap_err("failed to inspect directory")?;
+            if !metadata.is_dir() {
+                eyre::bail!("expected directory at {}", path.display());
+            }
+            ensure_secure_dir_permissions(path, &metadata)?;
+        } else {
+            fs::create_dir_all(path).wrap_err("failed to create directory")?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut permissions = fs::metadata(path)
+                    .wrap_err("failed to read directory metadata")?
+                    .permissions();
+                permissions.set_mode(0o700);
+                fs::set_permissions(path, permissions)
+                    .wrap_err("failed to set directory permissions")?;
+            }
+        }
+        Ok(())
+    }
+
+    fn write_json_secure<T: serde::Serialize>(
+        &self,
+        path: &Path,
+        value: &T,
+        overwrite: bool,
+    ) -> Result<()> {
+        let parent_dir: PathBuf = match path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            Some(parent) => parent.to_path_buf(),
+            None => env::current_dir()
+                .wrap_err("failed to resolve current directory for validator artifact")?,
+        };
+
+        self.ensure_secure_directory(&parent_dir)?;
+
+        if path.exists() {
+            if !overwrite {
+                eyre::bail!("refusing to overwrite existing file: {}", path.display());
+            }
+            ensure_secure_file_permissions(path)?;
+            fs::remove_file(path).wrap_err("failed to remove existing file")?;
+        }
+
+        let json =
+            serde_json::to_vec_pretty(value).wrap_err("failed to serialize validator artifact")?;
+        let mut temp_file =
+            NamedTempFile::new_in(&parent_dir).wrap_err("failed to create temp file")?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = temp_file.as_file().metadata()?.permissions();
+            permissions.set_mode(0o600);
+            temp_file.as_file().set_permissions(permissions)?;
+        }
+
+        temp_file
+            .write_all(&json)
+            .wrap_err("failed to write validator artifact")?;
+        temp_file
+            .as_file_mut()
+            .sync_all()
+            .wrap_err("failed to sync validator artifact")?;
+        temp_file.persist(path).map_err(|err| {
+            eyre::eyre!(
+                "failed to persist validator artifact {}: {}",
+                path.display(),
+                err
+            )
+        })?;
+        ensure_secure_file_permissions(path)?;
+        Ok(())
+    }
+
+    fn read_json_secure<T: serde::de::DeserializeOwned>(&self, path: &Path) -> Result<T> {
+        if !path.exists() {
+            eyre::bail!("validator artifact not found: {}", path.display());
+        }
+        ensure_secure_file_permissions(path)?;
+        let bytes = fs::read(path).wrap_err("failed to read validator artifact")?;
+        serde_json::from_slice(&bytes).wrap_err("failed to parse validator artifact")
+    }
+}
+
+fn ensure_secure_dir_permissions(path: &Path, metadata: &fs::Metadata) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode();
+        if mode & 0o077 != 0 {
+            eyre::bail!("directory {} is accessible to other users", path.display());
+        }
+    }
+    Ok(())
+}
+
+fn ensure_secure_file_permissions(path: &Path) -> Result<()> {
+    let metadata = fs::metadata(path).wrap_err("failed to read file metadata")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode();
+        if mode & 0o077 != 0 {
+            eyre::bail!("file {} is accessible to other users", path.display());
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn simple_crypto_is_deterministic() {
+        let provider = SimpleCryptoProvider::default();
+        let key = provider.generate_key("entropy").unwrap();
+        let withdrawal = "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        let genesis_root = "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        let deposit = provider
+            .create_deposit_data(&key, withdrawal, 32_000_000_000, [0, 0, 0, 0], genesis_root)
+            .unwrap();
+
+        let expected_secret = derive_secret_key("entropy").unwrap();
+        let expected_public = expected_secret.sk_to_pk();
+        let public_bytes = expected_public.to_bytes();
+        let expected_secret_hex = encode_hex(&expected_secret.to_bytes());
+        let expected_public_hex = encode_hex(&public_bytes);
+        assert_eq!(key.secret_key, expected_secret_hex);
+        assert_eq!(key.public_key, expected_public_hex);
+
+        let withdrawal_bytes = decode_hex_fixed::<32>(withdrawal).unwrap();
+        let message_root =
+            compute_deposit_message_root(&public_bytes, &withdrawal_bytes, 32_000_000_000);
+        let genesis_root_bytes = decode_hex_fixed::<32>(genesis_root).unwrap();
+        let domain = compute_deposit_domain([0, 0, 0, 0], &genesis_root_bytes);
+        let signing_root = compute_signing_root(&message_root, &domain);
+        let signature = expected_secret.sign(signing_root.as_ref(), BLS_DST, &[]);
+        let signature_bytes = signature.to_bytes();
+        let data_root = compute_deposit_data_root(
+            &public_bytes,
+            &withdrawal_bytes,
+            32_000_000_000,
+            &signature_bytes,
+        );
+
+        assert_eq!(deposit.deposit_message_root, encode_hex(&message_root));
+        assert_eq!(deposit.signature, encode_hex(&signature_bytes));
+        assert_eq!(deposit.deposit_data_root, encode_hex(&data_root));
+        assert_eq!(
+            deposit.withdrawal_credentials,
+            encode_hex(&withdrawal_bytes)
+        );
+        assert_eq!(deposit.fork_version, "0x00000000");
+    }
+
+    #[test]
+    fn filesystem_enforces_permissions() {
+        let fs_impl = StdValidatorFilesystem::default();
+        let dir = tempdir().unwrap();
+        let secure_dir = dir.path().join("secure");
+        fs_impl.ensure_secure_directory(&secure_dir).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&secure_dir).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&secure_dir, perms).unwrap();
+            let result = fs_impl.ensure_secure_directory(&secure_dir);
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn filesystem_allows_current_directory_targets() {
+        use std::path::Path;
+
+        let fs_impl = StdValidatorFilesystem::default();
+        let dir = tempdir().unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(dir.path()).unwrap().permissions();
+            perms.set_mode(0o700);
+            fs::set_permissions(dir.path(), perms).unwrap();
+        }
+
+        let original_dir = env::current_dir().unwrap();
+        env::set_current_dir(dir.path()).unwrap();
+
+        let key = ValidatorKey {
+            public_key: "pk".into(),
+            secret_key: "sk".into(),
+        };
+
+        let result = fs_impl.write_json_secure(Path::new("artifact.json"), &key, true);
+        env::set_current_dir(&original_dir).unwrap();
+
+        result.unwrap();
+        assert!(dir.path().join("artifact.json").exists());
+    }
+}

--- a/packages/core/src/infra/validator.rs
+++ b/packages/core/src/infra/validator.rs
@@ -77,6 +77,10 @@ impl CryptoProvider for SimpleCryptoProvider {
     }
 }
 
+/// Derives a BLS secret key deterministically from the provided entropy.
+///
+/// Callers must ensure the entropy is sourced from a high-quality RNG in
+/// production contexts—this helper does not add additional randomness.
 fn derive_secret_key(entropy: &str) -> Result<SecretKey> {
     let mut hasher = Sha256::new();
     hasher.update(entropy.as_bytes());
@@ -92,7 +96,10 @@ fn decode_hex(input: &str) -> Result<Vec<u8>> {
     let trimmed = input.trim();
     let without_prefix = trimmed.strip_prefix("0x").unwrap_or(trimmed);
     if without_prefix.len() % 2 != 0 {
-        return Err(eyre!("hex value must have an even length"));
+        return Err(eyre!(
+            "hex value must have an even length, got {} characters",
+            without_prefix.len()
+        ));
     }
     hex::decode(without_prefix).map_err(|err| eyre!("invalid hex: {err}"))
 }

--- a/packages/core/src/infra/validator.rs
+++ b/packages/core/src/infra/validator.rs
@@ -309,8 +309,11 @@ fn ensure_secure_dir_permissions(path: &Path, metadata: &fs::Metadata) -> Result
     {
         use std::os::unix::fs::PermissionsExt;
         let mode = metadata.permissions().mode();
-        if mode & 0o077 != 0 {
-            eyre::bail!("directory {} is accessible to other users", path.display());
+        if mode & 0o022 != 0 {
+            eyre::bail!(
+                "directory {} is writable by group or others",
+                path.display()
+            );
         }
     }
     Ok(())
@@ -392,7 +395,7 @@ mod tests {
         {
             use std::os::unix::fs::PermissionsExt;
             let mut perms = fs::metadata(&secure_dir).unwrap().permissions();
-            perms.set_mode(0o755);
+            perms.set_mode(0o775);
             fs::set_permissions(&secure_dir, perms).unwrap();
             let result = fs_impl.ensure_secure_directory(&secure_dir);
             assert!(result.is_err());

--- a/packages/core/src/infra/validator.rs
+++ b/packages/core/src/infra/validator.rs
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn simple_crypto_is_deterministic() {
-        let provider = SimpleCryptoProvider::default();
+        let provider = SimpleCryptoProvider;
         let key = provider.generate_key("entropy").unwrap();
         let withdrawal = "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
         let genesis_root = "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn filesystem_enforces_permissions() {
-        let fs_impl = StdValidatorFilesystem::default();
+        let fs_impl = StdValidatorFilesystem;
         let dir = tempdir().unwrap();
         let secure_dir = dir.path().join("secure");
         fs_impl.ensure_secure_directory(&secure_dir).unwrap();
@@ -396,7 +396,7 @@ mod tests {
     fn filesystem_allows_current_directory_targets() {
         use std::path::Path;
 
-        let fs_impl = StdValidatorFilesystem::default();
+        let fs_impl = StdValidatorFilesystem;
         let dir = tempdir().unwrap();
 
         #[cfg(unix)]


### PR DESCRIPTION
## Summary
- add validator domain logic with blst-based key generation and deposit serialization
- expose CLI and Tauri entrypoints that accept fork version and genesis validators root
- emit 0x-prefixed hex fields compatible with launchpad and deposit-cli

## Testing
- cargo test -p kittynode-core
- cargo check -p kittynode-cli
- cargo check -p kittynode-tauri
