### PR TITLE
Add settings modal for remote server connection

### DIFF
--- a/packages/app/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/packages/app/src/lib/components/ui/dialog/dialog-content.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+import { Dialog as DialogPrimitive } from "bits-ui";
+import XIcon from "@lucide/svelte/icons/x";
+import type { Snippet } from "svelte";
+import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+import DialogOverlay from "./dialog-overlay.svelte";
+
+let {
+  ref = $bindable(null),
+  class: className,
+  portalProps,
+  children,
+  ...restProps
+}: WithoutChildrenOrChild<DialogPrimitive.ContentProps> & {
+  portalProps?: DialogPrimitive.PortalProps;
+  children: Snippet;
+} = $props();
+</script>
+
+<DialogPrimitive.Portal {...portalProps}>
+  <DialogOverlay />
+  <DialogPrimitive.Content
+    bind:ref
+    data-slot="dialog-content"
+    class={cn(
+      "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+      "sm:rounded-lg",
+      className,
+    )}
+    {...restProps}
+  >
+    {@render children?.()}
+    <DialogPrimitive.Close
+      class="ring-offset-background focus-visible:ring-ring absolute right-4 top-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none"
+    >
+      <XIcon class="size-4" />
+      <span class="sr-only">Close</span>
+    </DialogPrimitive.Close>
+  </DialogPrimitive.Content>
+</DialogPrimitive.Portal>

--- a/packages/app/src/lib/components/ui/dialog/dialog-description.svelte
+++ b/packages/app/src/lib/components/ui/dialog/dialog-description.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import { Dialog as DialogPrimitive } from "bits-ui";
+import type { Snippet } from "svelte";
+import { cn, type WithElementRef } from "$lib/utils.js";
+
+let {
+  ref = $bindable(null),
+  class: className,
+  children,
+  ...restProps
+}: WithElementRef<DialogPrimitive.DescriptionProps> & {
+  children?: Snippet;
+} = $props();
+</script>
+
+<DialogPrimitive.Description
+  bind:ref
+  data-slot="dialog-description"
+  class={cn("text-sm text-muted-foreground", className)}
+  {...restProps}
+>
+  {@render children?.()}
+</DialogPrimitive.Description>

--- a/packages/app/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/packages/app/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { HTMLAttributes } from "svelte/elements";
+import { cn, type WithElementRef } from "$lib/utils.js";
+
+let {
+  ref = $bindable(null),
+  class: className,
+  children,
+  ...restProps
+}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="dialog-footer"
+  class={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:space-x-2", className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/packages/app/src/lib/components/ui/dialog/dialog-header.svelte
+++ b/packages/app/src/lib/components/ui/dialog/dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { HTMLAttributes } from "svelte/elements";
+import { cn, type WithElementRef } from "$lib/utils.js";
+
+let {
+  ref = $bindable(null),
+  class: className,
+  children,
+  ...restProps
+}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="dialog-header"
+  class={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/packages/app/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/packages/app/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import { Dialog as DialogPrimitive } from "bits-ui";
+import { cn } from "$lib/utils.js";
+
+let {
+  ref = $bindable(null),
+  class: className,
+  ...restProps
+}: DialogPrimitive.OverlayProps = $props();
+</script>
+
+<DialogPrimitive.Overlay
+  bind:ref
+  data-slot="dialog-overlay"
+  class={cn(
+    "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+    className,
+  )}
+  {...restProps}
+/>

--- a/packages/app/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/packages/app/src/lib/components/ui/dialog/dialog-title.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import { Dialog as DialogPrimitive } from "bits-ui";
+import type { Snippet } from "svelte";
+import { cn, type WithElementRef } from "$lib/utils.js";
+
+let {
+  ref = $bindable(null),
+  class: className,
+  children,
+  ...restProps
+}: WithElementRef<DialogPrimitive.TitleProps> & {
+  children?: Snippet;
+} = $props();
+</script>
+
+<DialogPrimitive.Title
+  bind:ref
+  data-slot="dialog-title"
+  class={cn("text-lg font-semibold leading-none tracking-tight", className)}
+  {...restProps}
+>
+  {@render children?.()}
+</DialogPrimitive.Title>

--- a/packages/app/src/lib/components/ui/dialog/index.ts
+++ b/packages/app/src/lib/components/ui/dialog/index.ts
@@ -1,0 +1,36 @@
+import { Dialog as DialogPrimitive } from "bits-ui";
+import Content from "./dialog-content.svelte";
+import Header from "./dialog-header.svelte";
+import Footer from "./dialog-footer.svelte";
+import Title from "./dialog-title.svelte";
+import Description from "./dialog-description.svelte";
+import Overlay from "./dialog-overlay.svelte";
+
+const Root = DialogPrimitive.Root;
+const Trigger = DialogPrimitive.Trigger;
+const Portal = DialogPrimitive.Portal;
+const Close = DialogPrimitive.Close;
+
+export {
+  Root,
+  Trigger,
+  Portal,
+  Close,
+  Overlay,
+  Content,
+  Header,
+  Footer,
+  Title,
+  Description,
+  //
+  Root as Dialog,
+  Trigger as DialogTrigger,
+  Portal as DialogPortal,
+  Close as DialogClose,
+  Overlay as DialogOverlay,
+  Content as DialogContent,
+  Header as DialogHeader,
+  Footer as DialogFooter,
+  Title as DialogTitle,
+  Description as DialogDescription,
+};


### PR DESCRIPTION
## Summary
- replace the remote server prompt with an in-app dialog that supports connect, update, and disconnect flows
- add reusable dialog primitives around bits-ui so the modal stays consistent and accessible
- polish the remote server form with inline validation, feedback spinners, and updated spacing

## Testing
- bun -F app format-lint
- just lint-js *(fails: website/src/routes/download/+page.svelte imports missing  icon; pre-existing)*