### PR TITLE
Persist remote server preference across sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,6 +2133,7 @@ dependencies = [
  "tokio-stream",
  "toml 0.9.7",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/packages/app/src/lib/types/config.ts
+++ b/packages/app/src/lib/types/config.ts
@@ -1,6 +1,8 @@
 export interface KittynodeConfig {
   capabilities: string[];
   serverUrl: string;
+  lastServerUrl: string;
+  remoteConnected: boolean;
   onboardingCompleted: boolean;
   autoStartDocker: boolean;
 }

--- a/packages/app/src/lib/types/config.ts
+++ b/packages/app/src/lib/types/config.ts
@@ -2,7 +2,7 @@ export interface KittynodeConfig {
   capabilities: string[];
   serverUrl: string;
   lastServerUrl: string;
-  remoteConnected: boolean;
+  hasRemoteServer: boolean;
   onboardingCompleted: boolean;
   autoStartDocker: boolean;
 }

--- a/packages/app/src/routes/settings/+page.svelte
+++ b/packages/app/src/routes/settings/+page.svelte
@@ -113,7 +113,10 @@ function validateRemoteUrl(url: string) {
 }
 
 function openRemoteDialog() {
-  remoteServerUrlInput = serverUrlStore.serverUrl || "http://localhost:3000";
+  remoteServerUrlInput =
+    serverUrlStore.serverUrl ||
+    serverUrlStore.lastServerUrl ||
+    "http://127.0.0.1:3000";
   remoteServerError = "";
   remoteDialogAction = null;
   remoteServerDialogOpen = true;

--- a/packages/app/src/stores/appConfig.svelte.ts
+++ b/packages/app/src/stores/appConfig.svelte.ts
@@ -11,7 +11,7 @@ async function loadConfig(): Promise<void> {
   loading = true;
   try {
     config = await coreClient.getConfig();
-    serverUrlStore.setFromConfig(config.serverUrl);
+    serverUrlStore.setFromConfig(config.serverUrl, config.lastServerUrl);
     initialized = true;
   } catch (e) {
     console.error(`Failed to load Kittynode config: ${e}`);
@@ -65,12 +65,23 @@ export const appConfigStore = {
     }
   },
   async setServerUrl(endpoint: string) {
+    const trimmedEndpoint = endpoint.trim();
+    const previousLast = config?.lastServerUrl ?? "";
+
     try {
-      await coreClient.setServerUrl(endpoint);
+      await coreClient.setServerUrl(trimmedEndpoint);
+      const nextLast = trimmedEndpoint !== "" ? trimmedEndpoint : previousLast;
+
       if (config) {
-        config = { ...config, serverUrl: endpoint };
+        config = {
+          ...config,
+          serverUrl: trimmedEndpoint,
+          lastServerUrl: nextLast,
+          remoteConnected: trimmedEndpoint !== "",
+        };
       }
-      serverUrlStore.setFromConfig(endpoint);
+
+      serverUrlStore.setFromConfig(trimmedEndpoint, nextLast);
     } catch (e) {
       console.error(`Failed to update server URL: ${e}`);
       throw e;

--- a/packages/app/src/stores/appConfig.svelte.ts
+++ b/packages/app/src/stores/appConfig.svelte.ts
@@ -66,7 +66,8 @@ export const appConfigStore = {
   },
   async setServerUrl(endpoint: string) {
     const trimmedEndpoint = endpoint.trim();
-    const previousLast = config?.lastServerUrl ?? "";
+    const previousLast =
+      config?.lastServerUrl ?? serverUrlStore.lastServerUrl ?? "";
 
     try {
       await coreClient.setServerUrl(trimmedEndpoint);
@@ -77,7 +78,7 @@ export const appConfigStore = {
           ...config,
           serverUrl: trimmedEndpoint,
           lastServerUrl: nextLast,
-          remoteConnected: trimmedEndpoint !== "",
+          hasRemoteServer: trimmedEndpoint !== "",
         };
       }
 

--- a/packages/app/src/stores/serverUrl.svelte.ts
+++ b/packages/app/src/stores/serverUrl.svelte.ts
@@ -1,10 +1,22 @@
 let serverUrl = $state("");
+let lastServerUrl = $state("");
+
+function normalize(url: string) {
+  return url.trim();
+}
 
 export const serverUrlStore = {
   get serverUrl() {
     return serverUrl;
   },
-  setFromConfig(url: string) {
-    serverUrl = url;
+  get lastServerUrl() {
+    return lastServerUrl;
+  },
+  setFromConfig(currentUrl: string, lastUrl: string) {
+    const normalizedCurrent = normalize(currentUrl);
+    const normalizedLast = normalize(lastUrl) || normalizedCurrent;
+
+    serverUrl = normalizedCurrent;
+    lastServerUrl = normalizedLast;
   },
 };

--- a/packages/app/src/stores/serverUrl.svelte.ts
+++ b/packages/app/src/stores/serverUrl.svelte.ts
@@ -1,7 +1,7 @@
 let serverUrl = $state("");
 let lastServerUrl = $state("");
 
-function normalize(url: string) {
+export function normalizeServerUrl(url: string) {
   return url.trim();
 }
 
@@ -13,8 +13,8 @@ export const serverUrlStore = {
     return lastServerUrl;
   },
   setFromConfig(currentUrl: string, lastUrl: string) {
-    const normalizedCurrent = normalize(currentUrl);
-    const normalizedLast = normalize(lastUrl) || normalizedCurrent;
+    const normalizedCurrent = normalizeServerUrl(currentUrl);
+    const normalizedLast = normalizeServerUrl(lastUrl) || normalizedCurrent;
 
     serverUrl = normalizedCurrent;
     lastServerUrl = normalizedLast;

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 version = "0.12.0"
 
 [dependencies]
+url = "2.5.4"
 bollard = "0.19.2"
 eyre = { version = "0.6.12", default-features = false, features = [
   "auto-install",

--- a/packages/core/src/application/add_capability.rs
+++ b/packages/core/src/application/add_capability.rs
@@ -5,7 +5,7 @@ use eyre::Result;
 pub fn add_capability(capability: &str) -> Result<()> {
     let mut config = ConfigStore::load()?;
     add_to_capabilities(&mut config.capabilities, capability);
-    ConfigStore::save(&config)?;
+    ConfigStore::save(&mut config)?;
     Ok(())
 }
 

--- a/packages/core/src/application/add_capability.rs
+++ b/packages/core/src/application/add_capability.rs
@@ -5,7 +5,7 @@ use eyre::Result;
 pub fn add_capability(capability: &str) -> Result<()> {
     let mut config = ConfigStore::load()?;
     add_to_capabilities(&mut config.capabilities, capability);
-    ConfigStore::save(&mut config)?;
+    ConfigStore::save_normalized(&mut config)?;
     Ok(())
 }
 

--- a/packages/core/src/application/init_kittynode.rs
+++ b/packages/core/src/application/init_kittynode.rs
@@ -15,7 +15,7 @@ pub fn init_kittynode() -> Result<()> {
         ..Default::default()
     };
 
-    ConfigStore::save(&mut config)?;
+    ConfigStore::save_normalized(&mut config)?;
     info!(
         "Initialized Kittynode, preserved onboarding_completed: {}",
         onboarding_completed

--- a/packages/core/src/application/init_kittynode.rs
+++ b/packages/core/src/application/init_kittynode.rs
@@ -10,12 +10,12 @@ pub fn init_kittynode() -> Result<()> {
     let onboarding_completed = existing_config.onboarding_completed;
 
     // Create fresh config but preserve onboarding state
-    let config = Config {
+    let mut config = Config {
         onboarding_completed,
         ..Default::default()
     };
 
-    ConfigStore::save(&config)?;
+    ConfigStore::save(&mut config)?;
     info!(
         "Initialized Kittynode, preserved onboarding_completed: {}",
         onboarding_completed

--- a/packages/core/src/application/remove_capability.rs
+++ b/packages/core/src/application/remove_capability.rs
@@ -6,6 +6,6 @@ pub fn remove_capability(capability: &str) -> Result<()> {
     if let Some(pos) = config.capabilities.iter().position(|x| x == capability) {
         config.capabilities.remove(pos);
     }
-    ConfigStore::save(&mut config)?;
+    ConfigStore::save_normalized(&mut config)?;
     Ok(())
 }

--- a/packages/core/src/application/remove_capability.rs
+++ b/packages/core/src/application/remove_capability.rs
@@ -6,6 +6,6 @@ pub fn remove_capability(capability: &str) -> Result<()> {
     if let Some(pos) = config.capabilities.iter().position(|x| x == capability) {
         config.capabilities.remove(pos);
     }
-    ConfigStore::save(&config)?;
+    ConfigStore::save(&mut config)?;
     Ok(())
 }

--- a/packages/core/src/application/set_auto_start_docker.rs
+++ b/packages/core/src/application/set_auto_start_docker.rs
@@ -6,7 +6,7 @@ use tracing::info;
 pub fn set_auto_start_docker(enabled: bool) -> Result<()> {
     let mut config = ConfigStore::load()?;
     config.auto_start_docker = enabled;
-    ConfigStore::save(&config)?;
+    ConfigStore::save(&mut config)?;
     info!("Set auto start docker to: {}", enabled);
     Ok(())
 }

--- a/packages/core/src/application/set_auto_start_docker.rs
+++ b/packages/core/src/application/set_auto_start_docker.rs
@@ -6,7 +6,7 @@ use tracing::info;
 pub fn set_auto_start_docker(enabled: bool) -> Result<()> {
     let mut config = ConfigStore::load()?;
     config.auto_start_docker = enabled;
-    ConfigStore::save(&mut config)?;
+    ConfigStore::save_normalized(&mut config)?;
     info!("Set auto start docker to: {}", enabled);
     Ok(())
 }

--- a/packages/core/src/application/set_onboarding_completed.rs
+++ b/packages/core/src/application/set_onboarding_completed.rs
@@ -5,7 +5,7 @@ use tracing::info;
 pub fn set_onboarding_completed(completed: bool) -> Result<()> {
     let mut config = ConfigStore::load()?;
     config.onboarding_completed = completed;
-    ConfigStore::save(&mut config)?;
+    ConfigStore::save_normalized(&mut config)?;
     info!("Set onboarding completed to: {}", completed);
     Ok(())
 }

--- a/packages/core/src/application/set_onboarding_completed.rs
+++ b/packages/core/src/application/set_onboarding_completed.rs
@@ -5,7 +5,7 @@ use tracing::info;
 pub fn set_onboarding_completed(completed: bool) -> Result<()> {
     let mut config = ConfigStore::load()?;
     config.onboarding_completed = completed;
-    ConfigStore::save(&config)?;
+    ConfigStore::save(&mut config)?;
     info!("Set onboarding completed to: {}", completed);
     Ok(())
 }

--- a/packages/core/src/application/set_server_url.rs
+++ b/packages/core/src/application/set_server_url.rs
@@ -1,20 +1,108 @@
+use crate::domain::config::Config;
 use crate::infra::config::ConfigStore;
-use eyre::Result;
+use eyre::{Result, eyre};
+use url::Url;
 
-pub fn set_server_url(endpoint: String) -> Result<()> {
-    let mut config = ConfigStore::load()?;
+fn validate_server_url(endpoint: &str) -> Result<()> {
+    if endpoint.is_empty() {
+        return Ok(());
+    }
+
+    let parsed = Url::parse(endpoint).map_err(|e| eyre!("invalid server URL '{endpoint}': {e}"))?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(eyre!(
+                "invalid server URL '{endpoint}': unsupported scheme '{other}'"
+            ));
+        }
+    }
+
+    if parsed.host_str().is_none() {
+        return Err(eyre!("invalid server URL '{endpoint}': missing host"));
+    }
+
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(eyre!(
+            "invalid server URL '{endpoint}': credentials are not supported"
+        ));
+    }
+
+    Ok(())
+}
+
+fn apply_server_url(config: &mut Config, endpoint: &str) -> Result<()> {
     let trimmed = endpoint.trim();
+
+    validate_server_url(trimmed)?;
 
     if trimmed.is_empty() {
         config.server_url.clear();
-        config.remote_connected = false;
+        config.has_remote_server = false;
     } else {
         let normalized = trimmed.to_string();
         config.server_url = normalized.clone();
         config.last_server_url = normalized;
-        config.remote_connected = true;
+        config.has_remote_server = true;
     }
 
-    ConfigStore::save(&config)?;
     Ok(())
+}
+
+pub fn set_server_url(endpoint: String) -> Result<()> {
+    let mut config = ConfigStore::load()?;
+    apply_server_url(&mut config, &endpoint)?;
+    ConfigStore::save(&mut config)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_server_url, validate_server_url};
+    use crate::domain::config::Config;
+
+    #[test]
+    fn validate_allows_empty_endpoint() {
+        assert!(validate_server_url("").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_invalid_scheme() {
+        let err =
+            validate_server_url("ftp://example.com").expect_err("expected validation failure");
+        assert!(err.to_string().contains("unsupported scheme"));
+    }
+
+    #[test]
+    fn apply_sets_server_url_and_last() {
+        let mut config = Config::default();
+        apply_server_url(&mut config, " http://example.com ").expect("apply should succeed");
+
+        assert_eq!(config.server_url, "http://example.com");
+        assert_eq!(config.last_server_url, "http://example.com");
+        assert!(config.has_remote_server);
+    }
+
+    #[test]
+    fn apply_clears_server_but_preserves_last() {
+        let mut config = Config::default();
+        apply_server_url(&mut config, "http://example.com").expect("initial apply should succeed");
+        apply_server_url(&mut config, "").expect("clearing should succeed");
+
+        assert_eq!(config.server_url, "");
+        assert_eq!(config.last_server_url, "http://example.com");
+        assert!(!config.has_remote_server);
+    }
+
+    #[test]
+    fn apply_does_not_mutate_on_validation_error() {
+        let mut config = Config::default();
+        let _err =
+            apply_server_url(&mut config, "not a url").expect_err("expected validation failure");
+
+        assert_eq!(config.server_url, "");
+        assert_eq!(config.last_server_url, "");
+        assert!(!config.has_remote_server);
+    }
 }

--- a/packages/core/src/application/set_server_url.rs
+++ b/packages/core/src/application/set_server_url.rs
@@ -3,7 +3,18 @@ use eyre::Result;
 
 pub fn set_server_url(endpoint: String) -> Result<()> {
     let mut config = ConfigStore::load()?;
-    config.server_url = endpoint;
+    let trimmed = endpoint.trim();
+
+    if trimmed.is_empty() {
+        config.server_url.clear();
+        config.remote_connected = false;
+    } else {
+        let normalized = trimmed.to_string();
+        config.server_url = normalized.clone();
+        config.last_server_url = normalized;
+        config.remote_connected = true;
+    }
+
     ConfigStore::save(&config)?;
     Ok(())
 }

--- a/packages/core/src/application/set_server_url.rs
+++ b/packages/core/src/application/set_server_url.rs
@@ -53,7 +53,7 @@ fn apply_server_url(config: &mut Config, endpoint: &str) -> Result<()> {
 pub fn set_server_url(endpoint: String) -> Result<()> {
     let mut config = ConfigStore::load()?;
     apply_server_url(&mut config, &endpoint)?;
-    ConfigStore::save(&mut config)?;
+    ConfigStore::save_normalized(&mut config)?;
     Ok(())
 }
 

--- a/packages/core/src/application/set_server_url.rs
+++ b/packages/core/src/application/set_server_url.rs
@@ -14,7 +14,7 @@ fn validate_server_url(endpoint: &str) -> Result<()> {
         "http" | "https" => {}
         other => {
             return Err(eyre!(
-                "invalid server URL '{endpoint}': unsupported scheme '{other}'"
+                "invalid server URL '{endpoint}': unsupported scheme '{other}' (expected http or https)"
             ));
         }
     }
@@ -93,6 +93,16 @@ mod tests {
         assert_eq!(config.server_url, "");
         assert_eq!(config.last_server_url, "http://example.com");
         assert!(!config.has_remote_server);
+    }
+
+    #[test]
+    fn apply_preserves_trailing_slash() {
+        let mut config = Config::default();
+        apply_server_url(&mut config, "https://example.com/ ").expect("apply should succeed");
+
+        assert_eq!(config.server_url, "https://example.com/");
+        assert_eq!(config.last_server_url, "https://example.com/");
+        assert!(config.has_remote_server);
     }
 
     #[test]

--- a/packages/core/src/domain/config.rs
+++ b/packages/core/src/domain/config.rs
@@ -9,7 +9,7 @@ pub struct Config {
     #[serde(default, alias = "last_server_url")]
     pub last_server_url: String,
     #[serde(default, alias = "remote_connected")]
-    pub remote_connected: bool,
+    pub has_remote_server: bool,
     #[serde(default, alias = "onboarding_completed")]
     pub onboarding_completed: bool,
     #[serde(default, alias = "auto_start_docker")]
@@ -17,23 +17,53 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn normalize(mut self) -> Self {
+    pub fn normalize(&mut self) {
         self.server_url = self.server_url.trim().to_string();
         let has_server_url = !self.server_url.is_empty();
 
-        let trimmed_last = self.last_server_url.trim();
-        self.last_server_url = if trimmed_last.is_empty() {
-            if has_server_url {
-                self.server_url.clone()
-            } else {
-                String::new()
-            }
+        if self.last_server_url.trim().is_empty() && has_server_url {
+            self.last_server_url = self.server_url.clone();
         } else {
-            trimmed_last.to_string()
+            self.last_server_url = self.last_server_url.trim().to_string();
+        }
+
+        self.has_remote_server = has_server_url;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    #[test]
+    fn normalizes_server_and_last_urls() {
+        let mut config = Config {
+            server_url: " https://example.com ".to_string(),
+            last_server_url: String::new(),
+            has_remote_server: false,
+            ..Default::default()
         };
 
-        self.remote_connected = has_server_url;
+        config.normalize();
 
-        self
+        assert_eq!(config.server_url, "https://example.com");
+        assert_eq!(config.last_server_url, "https://example.com");
+        assert!(config.has_remote_server);
+    }
+
+    #[test]
+    fn normalize_trims_last_url_and_updates_flag() {
+        let mut config = Config {
+            server_url: String::new(),
+            last_server_url: " https://cached.example.com ".to_string(),
+            has_remote_server: true,
+            ..Default::default()
+        };
+
+        config.normalize();
+
+        assert_eq!(config.server_url, "");
+        assert_eq!(config.last_server_url, "https://cached.example.com");
+        assert!(!config.has_remote_server);
     }
 }

--- a/packages/core/src/domain/config.rs
+++ b/packages/core/src/domain/config.rs
@@ -6,8 +6,34 @@ pub struct Config {
     pub capabilities: Vec<String>,
     #[serde(alias = "server_url")]
     pub server_url: String,
+    #[serde(default, alias = "last_server_url")]
+    pub last_server_url: String,
+    #[serde(default, alias = "remote_connected")]
+    pub remote_connected: bool,
     #[serde(default, alias = "onboarding_completed")]
     pub onboarding_completed: bool,
     #[serde(default, alias = "auto_start_docker")]
     pub auto_start_docker: bool,
+}
+
+impl Config {
+    pub fn normalize(mut self) -> Self {
+        self.server_url = self.server_url.trim().to_string();
+        let has_server_url = !self.server_url.is_empty();
+
+        let trimmed_last = self.last_server_url.trim();
+        self.last_server_url = if trimmed_last.is_empty() {
+            if has_server_url {
+                self.server_url.clone()
+            } else {
+                String::new()
+            }
+        } else {
+            trimmed_last.to_string()
+        };
+
+        self.remote_connected = has_server_url;
+
+        self
+    }
 }

--- a/packages/core/src/infra/config.rs
+++ b/packages/core/src/infra/config.rs
@@ -10,21 +10,24 @@ impl ConfigStore {
     pub fn load() -> Result<Config> {
         let config_path = Self::config_file_path()?;
         if !config_path.exists() {
-            return Ok(Config::default().normalize());
+            let mut config = Config::default();
+            config.normalize();
+            return Ok(config);
         }
         let toml_str = fs::read_to_string(config_path)?;
-        let config: Config = toml::from_str(&toml_str)?;
-        Ok(config.normalize())
+        let mut config: Config = toml::from_str(&toml_str)?;
+        config.normalize();
+        Ok(config)
     }
 
     /// Saves the configuration to a TOML file.
-    pub fn save(config: &Config) -> Result<()> {
+    pub fn save(config: &mut Config) -> Result<()> {
         let config_path = Self::config_file_path()?;
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let normalized = config.clone().normalize();
-        let toml_str = toml::to_string(&normalized)?;
+        config.normalize();
+        let toml_str = toml::to_string(config)?;
         fs::write(config_path, toml_str)?;
         Ok(())
     }

--- a/packages/core/src/infra/config.rs
+++ b/packages/core/src/infra/config.rs
@@ -20,13 +20,13 @@ impl ConfigStore {
         Ok(config)
     }
 
-    /// Saves the configuration to a TOML file after normalizing in place.
-    pub fn save(config: &mut Config) -> Result<()> {
+    /// Saves the configuration to a TOML file after normalizing it in place.
+    pub fn save_normalized(config: &mut Config) -> Result<()> {
+        config.normalize();
         let config_path = Self::config_file_path()?;
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        config.normalize();
         let toml_str = toml::to_string(config)?;
         fs::write(config_path, toml_str)?;
         Ok(())

--- a/packages/core/src/infra/config.rs
+++ b/packages/core/src/infra/config.rs
@@ -10,11 +10,11 @@ impl ConfigStore {
     pub fn load() -> Result<Config> {
         let config_path = Self::config_file_path()?;
         if !config_path.exists() {
-            return Ok(Config::default());
+            return Ok(Config::default().normalize());
         }
         let toml_str = fs::read_to_string(config_path)?;
-        let config = toml::from_str(&toml_str)?;
-        Ok(config)
+        let config: Config = toml::from_str(&toml_str)?;
+        Ok(config.normalize())
     }
 
     /// Saves the configuration to a TOML file.
@@ -23,7 +23,8 @@ impl ConfigStore {
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let toml_str = toml::to_string(config)?;
+        let normalized = config.clone().normalize();
+        let toml_str = toml::to_string(&normalized)?;
         fs::write(config_path, toml_str)?;
         Ok(())
     }

--- a/packages/core/src/infra/config.rs
+++ b/packages/core/src/infra/config.rs
@@ -6,7 +6,7 @@ use std::{fs, path::PathBuf};
 pub struct ConfigStore;
 
 impl ConfigStore {
-    /// Loads the configuration from a TOML file.
+    /// Loads the configuration from a TOML file and normalizes it before returning.
     pub fn load() -> Result<Config> {
         let config_path = Self::config_file_path()?;
         if !config_path.exists() {
@@ -20,7 +20,7 @@ impl ConfigStore {
         Ok(config)
     }
 
-    /// Saves the configuration to a TOML file.
+    /// Saves the configuration to a TOML file after normalizing in place.
     pub fn save(config: &mut Config) -> Result<()> {
         let config_path = Self::config_file_path()?;
         if let Some(parent) = config_path.parent() {


### PR DESCRIPTION
## Summary
- keep remote connect form default on 127.0.0.1 while remembering the most recent endpoint
- persist active and last remote URLs plus connection status in the config store so reconnect survives restarts
- expose the new config fields to the app stores for consistent UI population

## Testing
- just lint-js
- cargo test