### PR TITLE
Enable remote access toggle to manage kittynode-web

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@
 - If needed, read the architecture documentation here: `./docs/src/content/docs/reference/architecture.mdx`.
 - If making changes to the architecture, update the architecture documentation.
 
+### Remote access
+
+- The desktop toggle now starts/stops `kittynode-web` via the CLI binary. When enabled, the service listens on the port reported in Settings/System Info (default 3000).
+- `~/.kittynode/runtime/kittynode-web.json` tracks PID/port, and logs stream to `~/.kittynode/runtime/kittynode-web.log`.
+- Expose the port only on trusted networks; the UI surfaces errors from the toggle so operators can react quickly.
+- The toggle requires the CLI binary (`kittynode`/`kittynode-cli`) to be on disk or provided via `KITTYNODE_CLI_PATH`.
+- A per-launch service token is injected via the `KITTYNODE_WEB_SERVICE_TOKEN` environment variable; ensure untrusted users cannot read parent process memory/environment.
+
 ## Development Setup
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,6 +2142,7 @@ dependencies = [
  "async-trait",
  "eyre",
  "kittynode-core",
+ "kittynode-web",
  "once_cell",
  "serde",
  "serde_json",

--- a/packages/app/src-tauri/Cargo.toml
+++ b/packages/app/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ eyre = { version = "0.6.12", default-features = false, features = [
 ] }
 async-trait = "0.1.89"
 kittynode-core = { version = "0.12.0", path = "../../core" }
+kittynode-web = { version = "0.9.0", path = "../../web" }
 once_cell = "1.21.3"
 serde = { version = "1.0.226", features = ["derive"] }
 serde_json = "1.0.145"

--- a/packages/app/src/lib/client.ts
+++ b/packages/app/src/lib/client.ts
@@ -7,6 +7,7 @@ import type {
   PackageConfig,
   PackageRuntimeState,
   SystemInfo,
+  WebServiceStatus,
 } from "$lib/types";
 
 export type DockerStartStatus =
@@ -97,6 +98,28 @@ export const coreClient = {
 
   updatePackageConfig(name: string, config: PackageConfig): Promise<void> {
     return invoke("update_package_config", { name, config });
+  },
+
+  /**
+   * Start the local kittynode-web service so remote clients can connect.
+   */
+  startWebService(port?: number): Promise<WebServiceStatus> {
+    const payload = port === undefined ? {} : { port };
+    return invoke<WebServiceStatus>("start_web_service", payload);
+  },
+
+  /**
+   * Stop the kittynode-web service if it is currently running.
+   */
+  stopWebService(): Promise<WebServiceStatus> {
+    return invoke<WebServiceStatus>("stop_web_service");
+  },
+
+  /**
+   * Retrieve the latest kittynode-web runtime status.
+   */
+  getWebServiceStatus(): Promise<WebServiceStatus> {
+    return invoke<WebServiceStatus>("get_web_service_status");
   },
 
   getPackageRuntimeStates(

--- a/packages/app/src/lib/types/index.ts
+++ b/packages/app/src/lib/types/index.ts
@@ -2,3 +2,4 @@ export * from "./package";
 export * from "./config";
 export * from "./operational_state";
 export * from "./system_info";
+export * from "./web_service";

--- a/packages/app/src/lib/types/web_service.ts
+++ b/packages/app/src/lib/types/web_service.ts
@@ -1,0 +1,10 @@
+export type WebServiceState =
+  | "started"
+  | "already_running"
+  | "stopped"
+  | "not_running";
+
+export interface WebServiceStatus {
+  status: WebServiceState;
+  port: number | null;
+}

--- a/packages/app/src/routes/system-info/+page.svelte
+++ b/packages/app/src/routes/system-info/+page.svelte
@@ -32,10 +32,15 @@ onMount(() => {
   if (!systemInfoStore.systemInfo) {
     fetchSystemInfo();
   }
+  if (remoteAccessStore.status === null) {
+    void remoteAccessStore.refresh();
+  }
+  remoteAccessStore.startPolling();
   operationalStateStore.startPolling();
 
   return () => {
     operationalStateStore.stopPolling();
+    remoteAccessStore.stopPolling();
   };
 });
 </script>
@@ -71,11 +76,21 @@ onMount(() => {
           {#if remoteAccessStore.remoteAccess}
             <Globe class="h-4 w-4 text-green-500" />
             <span class="text-sm font-medium">Enabled</span>
+            {#if remoteAccessStore.port !== null}
+              <span class="text-xs text-muted-foreground">
+                (http://localhost:{remoteAccessStore.port})
+              </span>
+            {/if}
           {:else}
             <WifiOff class="h-4 w-4 text-muted-foreground" />
             <span class="text-sm font-medium">Disabled</span>
           {/if}
         </div>
+        {#if remoteAccessStore.lastError}
+          <p class="mt-2 text-xs text-destructive">
+            {remoteAccessStore.lastError}
+          </p>
+        {/if}
       </Card.Content>
     </Card.Root>
 

--- a/packages/app/src/stores/remoteAccess.svelte.ts
+++ b/packages/app/src/stores/remoteAccess.svelte.ts
@@ -1,13 +1,113 @@
-let remoteAccess = $state(false);
+import { coreClient } from "$lib/client";
+import type { WebServiceStatus, WebServiceState } from "$lib/types";
+
+let status = $state<WebServiceStatus | null>(null);
+let loading = $state(false);
+let lastError = $state<string | null>(null);
+let pollHandle: number | null = null;
+
+function isRunning(state: WebServiceState | null) {
+  return state === "started" || state === "already_running";
+}
+
+function applyStatus(next: WebServiceStatus) {
+  status = next;
+  lastError = null;
+}
+
+function recordError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  lastError = message;
+  console.error(`Remote access error: ${message}`);
+}
+
+async function refresh(): Promise<WebServiceStatus | null> {
+  loading = true;
+  try {
+    const result = await coreClient.getWebServiceStatus();
+    applyStatus(result);
+    return result;
+  } catch (error) {
+    recordError(error);
+    return null;
+  } finally {
+    loading = false;
+  }
+}
+
+async function enable(port?: number): Promise<WebServiceStatus> {
+  loading = true;
+  try {
+    const result = await coreClient.startWebService(port);
+    applyStatus(result);
+    return result;
+  } catch (error) {
+    recordError(error);
+    throw error;
+  } finally {
+    loading = false;
+  }
+}
+
+async function disable(): Promise<WebServiceStatus> {
+  loading = true;
+  try {
+    const result = await coreClient.stopWebService();
+    applyStatus(result);
+    return result;
+  } catch (error) {
+    recordError(error);
+    throw error;
+  } finally {
+    loading = false;
+  }
+}
+
+function startPolling(interval = DEFAULT_POLL_INTERVAL_MS) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  stopPolling();
+  void refresh();
+  pollHandle = window.setInterval(() => {
+    void refresh();
+  }, interval);
+}
+
+function stopPolling() {
+  if (pollHandle !== null && typeof window !== "undefined") {
+    window.clearInterval(pollHandle);
+    pollHandle = null;
+  }
+}
 
 export const remoteAccessStore = {
   get remoteAccess() {
-    return remoteAccess;
+    return isRunning(status?.status ?? null);
   },
-  async enable() {
-    remoteAccess = true;
+  get status() {
+    return status;
+  },
+  get port() {
+    return status?.port ?? null;
+  },
+  get loading() {
+    return loading;
+  },
+  get lastError() {
+    return lastError;
+  },
+  async refresh() {
+    return refresh();
+  },
+  async enable(port?: number) {
+    return enable(port);
   },
   async disable() {
-    remoteAccess = false;
+    return disable();
   },
+  startPolling,
+  stopPolling,
 };
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;


### PR DESCRIPTION
## Summary
- wire the remote access toggle to start/stop kittynode-web via new tauri commands
- surface listening port and status in settings and system info views
- add shared web service types and store plumbing for status tracking

## Testing
- just lint-rs
- just lint-js (fails: existing CircleQuestionMark export error in website/src/routes/download/+page.svelte)