### PR TITLE
Refresh onboarding splash walkthrough

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@fontsource-variable/literata": "^5.2.6",
+    "@fontsource-variable/space-grotesk": "^5.2.9",
     "@internationalized/date": "^3.9.0",
     "@lucide/svelte": "^0.515.0",
     "@sveltejs/adapter-static": "^3.0.9",

--- a/packages/app/src/app.css
+++ b/packages/app/src/app.css
@@ -1,4 +1,5 @@
 @import "@fontsource-variable/literata";
+@import "@fontsource-variable/space-grotesk";
 
 @import "tailwindcss";
 
@@ -143,6 +144,10 @@
   .kittynode-brand {
     font-family: "Literata Variable", serif;
     font-weight: 500;
-    font-size: 1.5rem;
+    font-size: 1.65rem;
+  }
+
+  .kittynode-onboard-font {
+    font-family: "Space Grotesk Variable", sans-serif;
   }
 }

--- a/packages/app/src/app.css
+++ b/packages/app/src/app.css
@@ -144,7 +144,7 @@
   .kittynode-brand {
     font-family: "Literata Variable", serif;
     font-weight: 500;
-    font-size: 1.65rem;
+    font-size: 1.5rem;
   }
 
   .kittynode-onboard-font {

--- a/packages/app/src/routes/Splash.svelte
+++ b/packages/app/src/routes/Splash.svelte
@@ -4,59 +4,48 @@ import { goto } from "$app/navigation";
 import { platform } from "@tauri-apps/plugin-os";
 import { coreClient } from "$lib/client";
 import { onMount } from "svelte";
-import { mode } from "mode-watcher";
 import { toast } from "svelte-sonner";
 import { Button } from "$lib/components/ui/button";
-import * as Card from "$lib/components/ui/card";
+import { Progress } from "$lib/components/ui/progress";
+import { mode } from "mode-watcher";
+import { ArrowUpRight } from "@lucide/svelte";
 
 let currentPlatform = $state("");
+let currentStep = $state(0);
+
+const totalSteps = 2;
+const isFirstStep = $derived(currentStep === 0);
+const isLastStep = $derived(currentStep === totalSteps - 1);
+const progressValue = $derived(
+  totalSteps <= 1 ? 100 : (currentStep / (totalSteps - 1)) * 100,
+);
+const isInitializing = $derived(initializedStore.initializing);
+
 let canvasElement: HTMLCanvasElement;
 let animationFrameId: number;
 let ctx: CanvasRenderingContext2D;
 
-async function initKittynode() {
-  try {
-    if (["ios", "android"].includes(currentPlatform)) {
-      await initializedStore.fakeInitialize();
-    } else {
-      await initializedStore.initialize();
-    }
-    // Mark onboarding as completed
-    try {
-      await coreClient.setOnboardingCompleted(true);
-    } catch (e) {
-      console.error(`Failed to save onboarding state: ${e}`);
-      toast.error("Failed to save onboarding progress");
-    }
-  } catch (e) {
-    console.error(`Failed to initialize kittynode: ${e}`);
-    toast.error("Failed to initialize Kittynode");
-    return; // Don't navigate if initialization failed
-  }
-  await goto("/");
-}
-
-interface Node {
+type NodePoint = {
   x: number;
   y: number;
   vx: number;
   vy: number;
-}
+};
 
 onMount(() => {
   currentPlatform = platform();
 
   const canvas = canvasElement;
-  const context = canvas.getContext("2d");
+  const context = canvas?.getContext("2d");
   if (!context) {
     console.error("Please report this error: Failed to get 2D context.");
     return;
   }
   ctx = context;
 
-  const nodes: Node[] = [];
-  const maxVelocity = 1.5;
-  const nodeDensity = 0.0001;
+  const nodes: NodePoint[] = [];
+  const maxVelocity = 1.2;
+  const nodeDensity = 0.00008;
 
   function calculateNumNodes() {
     return Math.round(window.innerWidth * window.innerHeight * nodeDensity);
@@ -86,18 +75,20 @@ onMount(() => {
     }
 
     for (const node of nodes) {
-      if (node.x > window.innerWidth)
+      if (node.x > window.innerWidth) {
         node.x = Math.random() * window.innerWidth;
-      if (node.y > window.innerHeight)
+      }
+      if (node.y > window.innerHeight) {
         node.y = Math.random() * window.innerHeight;
+      }
     }
   }
 
-  resizeCanvas(); // Initialize canvas dimensions and nodes
+  resizeCanvas();
   window.addEventListener("resize", resizeCanvas);
 
   function animate() {
-    ctx.fillStyle = mode.current === "dark" ? "#0a0a0a" : "#FFFFFF";
+    ctx.fillStyle = mode.current === "dark" ? "#09090b" : "#f5f5f7";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     for (const node of nodes) {
@@ -107,8 +98,8 @@ onMount(() => {
       if (node.y <= 0 || node.y >= window.innerHeight) node.vy *= -1;
 
       ctx.beginPath();
-      ctx.arc(node.x, node.y, 2, 0, Math.PI * 2);
-      ctx.fillStyle = mode.current === "dark" ? "#FFFFFF" : "#000000";
+      ctx.arc(node.x, node.y, 1.8, 0, Math.PI * 2);
+      ctx.fillStyle = mode.current === "dark" ? "#FFFFFF" : "#111111";
       ctx.fill();
     }
 
@@ -118,13 +109,13 @@ onMount(() => {
         const dy = nodes[i].y - nodes[j].y;
         const distance = Math.hypot(dx, dy);
 
-        if (distance < 100) {
+        if (distance < 110) {
           ctx.beginPath();
           ctx.moveTo(nodes[i].x, nodes[i].y);
           ctx.lineTo(nodes[j].x, nodes[j].y);
-          const color = mode.current === "dark" ? "255, 255, 255" : "0, 0, 0";
-          ctx.strokeStyle = `rgba(${color}, ${1 - distance / 100})`;
-          ctx.lineWidth = 1;
+          const color = mode.current === "dark" ? "255,255,255" : "17,17,17";
+          ctx.strokeStyle = `rgba(${color}, ${1 - distance / 110})`;
+          ctx.lineWidth = 0.9;
           ctx.stroke();
         }
       }
@@ -140,29 +131,123 @@ onMount(() => {
     window.removeEventListener("resize", resizeCanvas);
   };
 });
+
+function nextStep() {
+  if (!isLastStep) {
+    currentStep += 1;
+  }
+}
+
+function prevStep() {
+  if (!isFirstStep) {
+    currentStep -= 1;
+  }
+}
+
+async function initKittynode() {
+  try {
+    if (["ios", "android"].includes(currentPlatform)) {
+      await initializedStore.fakeInitialize();
+    } else {
+      await initializedStore.initialize();
+    }
+    try {
+      await coreClient.setOnboardingCompleted(true);
+    } catch (e) {
+      console.error(`Failed to save onboarding state: ${e}`);
+      toast.error("Failed to save onboarding progress");
+    }
+  } catch (e) {
+    console.error(`Failed to initialize kittynode: ${e}`);
+    toast.error("Failed to initialize Kittynode");
+    return;
+  }
+
+  await goto("/");
+}
 </script>
 
-<canvas class="fixed -z-10 top-0 left-0" bind:this={canvasElement}></canvas>
+<canvas class="fixed inset-0 -z-10" bind:this={canvasElement}></canvas>
 
-<main class="relative z-[1] min-h-svh w-full flex items-center justify-center text-center p-4">
-  <Card.Root class="min-w-80 max-w-md mx-4">
-    <Card.Header class="flex flex-col items-center">
-      <img
-      class="logo w-24"
-      src={`/images/kittynode-logo-app-no-padding.png`}
-      alt="Kittynode Logo"
-    />
-      <Card.Title class="kittynode-brand mt-2">Kittynode</Card.Title>
-      <Card.Description>
-        <div class="mt-3">Control center for world computer operators.</div>
-      </Card.Description>
-    </Card.Header>
-    <Card.Content>
-      <Button
-        onclick={initKittynode}
-      >
-        Get Started
-      </Button>
-    </Card.Content>
-  </Card.Root>
+<main class="relative z-10 flex min-h-svh w-full items-center justify-center px-6 py-10 sm:px-10 sm:py-16">
+  <section class="flex w-full max-w-4xl flex-col rounded-[2rem] border border-border/40 bg-background/90 px-6 py-10 shadow-none backdrop-blur-sm sm:px-12 sm:py-14">
+    <header class="space-y-6 kittynode-onboard-font">
+      <div class="flex flex-wrap items-center gap-3">
+        <div class="flex items-center gap-3">
+          <img
+            src="/images/kittynode-logo-app-no-padding.png"
+            alt="Kittynode Logo"
+            class="h-12 w-12"
+          />
+          <span class="kittynode-brand text-[1.9rem] leading-none sm:text-[2.1rem]">Kittynode</span>
+        </div>
+      </div>
+      <Progress value={progressValue} class="h-1" />
+    </header>
+
+    <div class="kittynode-onboard-font mt-8 min-h-[240px]">
+      {#if currentStep === 0}
+        <div class="flex h-full flex-col justify-center gap-6 text-left">
+          <div class="space-y-2">
+            <h1 class="font-medium leading-tight text-[1.9rem] text-foreground sm:text-[2rem]">
+              Welcome to Kittynode
+            </h1>
+            <p class="text-base text-muted-foreground sm:text-lg">
+              Operate the world computer. Secure the Ethereum network and earn rewards.
+            </p>
+          </div>
+        </div>
+      {:else}
+        <div class="flex h-full flex-col justify-center gap-6 text-left">
+          <div class="space-y-2">
+            <h2 class="font-medium leading-tight text-[1.9rem] text-foreground sm:text-[2rem]">
+              Install Docker Desktop
+            </h2>
+            <p class="text-base text-muted-foreground sm:text-lg">
+              Kittynode isolates your node stack inside Docker. Install Docker Desktop before you launch.
+            </p>
+          </div>
+        </div>
+      {/if}
+    </div>
+
+    <footer class="kittynode-onboard-font mt-12 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      {#if currentStep === totalSteps - 1}
+        <a
+          class="link inline-flex items-center gap-1 text-base font-medium"
+          href="https://www.docker.com/products/docker-desktop/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Download Docker Desktop
+          <ArrowUpRight class="h-4 w-4" />
+        </a>
+      {:else}
+        <span class="text-sm text-muted-foreground">Step 1 of 2</span>
+      {/if}
+      <div class="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          onclick={prevStep}
+          disabled={isFirstStep || isInitializing}
+          class="min-w-[104px]"
+        >
+          Back
+        </Button>
+        {#if isLastStep}
+          <Button onclick={initKittynode} disabled={isInitializing} class="min-w-[104px]">
+            {#if isInitializing}
+              Launching...
+            {:else}
+              Launch
+            {/if}
+          </Button>
+        {:else}
+          <Button onclick={nextStep} class="min-w-[104px]">
+            Next
+          </Button>
+        {/if}
+      </div>
+    </footer>
+  </section>
 </main>


### PR DESCRIPTION
## Summary
- rebuild the onboarding splash as a two-step walkthrough with fixed layout and animated backdrop
- refine messaging, remove the rhino art, and surface the Docker download as a primary link
- scope Space Grotesk to the walkthrough and add the font dependency for the app workspace

## Testing
- just lint-js
