### PR TITLE
Refactor website hero to fluid responsive layout; add Store link; refine header spacing

### DIFF
--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -22,7 +22,7 @@ let { children } = $props();
 
 <div class="flex min-h-screen flex-col">
   <div class="mx-auto flex min-h-screen w-full max-w-[100ch] flex-col px-6">
-    <header class="flex h-16 items-center justify-between border-b px-1">
+    <header class="flex h-16 items-center justify-between border-b px-0.5">
       <a href="/" class="wordmark">
         <picture>
           <source

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -41,7 +41,7 @@ let { children } = $props();
         <span class="wordmark-text">Kittynode</span>
       </a>
 
-      <nav class="flex items-center gap-8">
+      <nav class="flex items-center gap-7">
         <a href="https://docs.kittynode.com" class="nav-link">
           Docs
         </a>
@@ -57,7 +57,7 @@ let { children } = $props();
 
     <footer class="border-t py-6">
       <div class="flex flex-col items-center gap-4">
-        <div class="flex items-center gap-8 text-sm">
+        <div class="flex items-center gap-7 text-sm">
           <a href="https://discord.kittynode.com" class="nav-link">
             Discord
           </a>

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -22,7 +22,7 @@ let { children } = $props();
 
 <div class="flex min-h-screen flex-col">
   <div class="mx-auto flex min-h-screen w-full max-w-[100ch] flex-col px-6">
-    <header class="flex h-16 items-center justify-between border-b">
+    <header class="flex h-16 items-center justify-between border-b px-1">
       <a href="/" class="wordmark">
         <picture>
           <source
@@ -41,9 +41,12 @@ let { children } = $props();
         <span class="wordmark-text">Kittynode</span>
       </a>
 
-      <nav class="flex items-center gap-2">
+      <nav class="flex items-center gap-5">
         <a href="https://docs.kittynode.com" class="nav-link">
           Docs
+        </a>
+        <a href="/store" class="nav-link">
+          Store
         </a>
       </nav>
     </header>

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -41,7 +41,7 @@ let { children } = $props();
         <span class="wordmark-text">Kittynode</span>
       </a>
 
-      <nav class="flex items-center gap-5">
+      <nav class="flex items-center gap-8">
         <a href="https://docs.kittynode.com" class="nav-link">
           Docs
         </a>

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -41,7 +41,7 @@ let { children } = $props();
         <span class="wordmark-text">Kittynode</span>
       </a>
 
-      <nav class="flex items-center gap-7">
+      <nav class="flex items-center gap-6">
         <a href="https://docs.kittynode.com" class="nav-link">
           Docs
         </a>
@@ -57,7 +57,7 @@ let { children } = $props();
 
     <footer class="border-t py-6">
       <div class="flex flex-col items-center gap-4">
-        <div class="flex items-center gap-7 text-sm">
+        <div class="flex items-center gap-8 text-sm">
           <a href="https://discord.kittynode.com" class="nav-link">
             Discord
           </a>

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -84,69 +84,54 @@ onMount(() => {
 });
 </script>
 
-<div class="flex flex-1 items-center justify-center py-16">
+<div class="flex flex-1 items-center justify-center pb-[clamp(2rem,6vh,5rem)] pt-[clamp(3.75rem,12vh,8.5rem)]">
   <div class="w-full">
-    <div class="mx-auto max-w-3xl text-center">
-      <h1 class="hero-heading">Operate the world computer</h1>
-      <p class="hero-subtitle mt-6 text-muted-foreground">
-        Kittynode is a control center for world computer operators.
-      </p>
-      <img src="/black-kitty.gif" alt="Black Kitty" class="nyan-cat mt-12" />
-      <div class="mt-8 flex flex-col items-center gap-4">
-        <Button href={downloadHref} size="lg" class="gap-2">
-          <Download class="h-5 w-5" />
-          {downloadButtonText}
-        </Button>
-        {#if showFallback}
-          <p class="text-sm text-muted-foreground">
-            Available for Linux, macOS, and Windows.
+    <div class="mx-auto text-center">
+      <h1
+        class="text-balance font-medium leading-tight tracking-tight text-[clamp(2.125rem,3vw+0.75rem,3.25rem)]"
+      >
+        Operate the world computer
+      </h1>
+      <div class="mx-auto max-w-[68ch] mt-[clamp(1.25rem,3vh,2rem)]">
+        <div class="flex flex-col items-center space-y-[clamp(1.25rem,3.5vh,2.25rem)]">
+          <p
+          class="text-[clamp(1.1rem,1.1vw+0.35rem,1.3rem)] text-muted-foreground"
+        >
+            Kittynode is a control center for world computer operators.
           </p>
-        {:else}
-          <p class="text-sm text-muted-foreground">
-            Need something else? <a href="/download" class="link">See all downloads</a>.
-          </p>
-        {/if}
+          <img
+            src="/black-kitty.gif"
+            alt="Black Kitty"
+            class="nyan-cat mx-auto w-[clamp(160px,20vw,210px)]"
+          />
+          <div class="flex flex-col items-center gap-[clamp(0.9rem,2.2vh,1.5rem)]">
+            <Button href={downloadHref} size="lg" class="gap-2">
+              <Download class="h-5 w-5" />
+              {downloadButtonText}
+            </Button>
+            {#if showFallback}
+              <p class="text-sm text-muted-foreground">
+                Available for Linux, macOS, and Windows.
+              </p>
+            {:else}
+              <p class="text-sm text-muted-foreground">
+                Need something else? <a href="/download" class="link">See all downloads</a>.
+              </p>
+            {/if}
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </div>
 
 <style>
-  .hero-heading {
-    font-size: 2.25rem;
-    font-weight: 500;
-  }
-
-  .hero-subtitle {
-    font-size: 1rem;
-  }
-
-  @media (min-width: 640px) {
-    .hero-heading {
-      font-size: 3rem;
-      font-weight: 500;
-    }
-
-    .hero-subtitle {
-      font-size: 1.25rem;
-    }
-  }
-
   .nyan-cat {
-    width: 180px;
-    height: auto;
-    min-width: 180px;
-    max-width: none;
     image-rendering: pixelated;
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
   }
 
-  @media (min-width: 640px) {
-    .nyan-cat {
-      width: 220px;
-      min-width: 220px;
-    }
+  /* Balanced headings for nicer line breaks */
+  .text-balance {
+    text-wrap: balance;
   }
 </style>


### PR DESCRIPTION
This PR refines the website hero and header for cleaner, fluid responsiveness and tasteful spacing.\n\nHero changes\n- Fluid clamp-based typography and spacing across viewports\n- Balanced heading wrapping; H1 stays single-line on common desktops\n- Increased hero top padding with viewport-based clamp to sit slightly lower\n- Consistent vertical rhythm via a simple stack (subtitle, image, CTA)\n- Reduced max size of Black Kitty image on large screens\n- Raised minimum font sizes for better readability on small/medium\n\nHeader changes\n- Add Store link to the right of Docs\n- Very subtle horizontal inset: px-0.5\n- Header nav spacing set to gap-6; footer links at gap-8\n\nNotes\n- No architecture changes\n- No new routes added beyond the Store link target (currently /store)\n\nLet me know if you want the Store link to point to an external URL or if we should add a /store route.