### PR TITLE
Add CLI web restart command

### DIFF
--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -334,7 +334,18 @@ pub fn stop_web_service() -> Result<()> {
 }
 
 pub fn restart_web_service(port: Option<u16>) -> Result<()> {
-    stop_web_service()?;
+    let port = match port {
+        Some(port) => Some(port),
+        None => match api::get_web_service_status()? {
+            WebServiceStatus::Started { port, .. }
+            | WebServiceStatus::AlreadyRunning { port, .. } => Some(port),
+            _ => None,
+        },
+    };
+
+    let status = api::stop_web_service()?;
+    println!("{}", status);
+
     start_web_service(port)
 }
 

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -333,6 +333,11 @@ pub fn stop_web_service() -> Result<()> {
     Ok(())
 }
 
+pub fn restart_web_service(port: Option<u16>) -> Result<()> {
+    stop_web_service()?;
+    start_web_service(port)
+}
+
 pub fn web_status() -> Result<()> {
     match api::get_web_service_status()? {
         WebServiceStatus::Started { pid, port }

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -286,6 +286,15 @@ enum WebCommands {
         )]
         port: Option<u16>,
     },
+    #[command(name = "restart", about = "Restart the Kittynode web service")]
+    Restart {
+        #[arg(
+            long = "port",
+            value_name = "PORT",
+            help = "Port to bind the Kittynode web service"
+        )]
+        port: Option<u16>,
+    },
     #[command(name = "stop", about = "Stop the Kittynode web service")]
     Stop,
     #[command(name = "status", about = "Show Kittynode web service status")]
@@ -450,6 +459,7 @@ impl WebCommands {
     async fn execute(self) -> Result<()> {
         match self {
             WebCommands::Start { port } => commands::start_web_service(port),
+            WebCommands::Restart { port } => commands::restart_web_service(port),
             WebCommands::Stop => commands::stop_web_service(),
             WebCommands::Status => commands::web_status(),
             WebCommands::Logs { follow, tail } => commands::web_logs(follow, tail),


### PR DESCRIPTION
## Summary
- add a restart subcommand under kittynode web
- reuse existing stop/start helpers to chain the restart
- keep optional port override available during restart

## Testing
- just lint-rs