### PR TITLE
Add unit coverage for docker socket and onboarding decisions

### DIFF
--- a/packages/core/src/application/get_onboarding_completed.rs
+++ b/packages/core/src/application/get_onboarding_completed.rs
@@ -10,3 +10,51 @@ pub fn get_onboarding_completed() -> Result<bool> {
     );
     Ok(config.onboarding_completed)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::get_onboarding_completed;
+    use crate::application::set_onboarding_completed;
+    use std::env;
+    use tempfile::tempdir;
+
+    fn with_temp_home<F, R>(f: F) -> R
+    where
+        F: FnOnce(&std::path::Path) -> R,
+    {
+        let _lock = crate::ENV_GUARD.lock().expect("lock poisoned");
+        let original_home = env::var_os("HOME");
+        let temp = tempdir().expect("tempdir failed");
+        // Newer toolchains mark environment mutation unsafe; scope it with a guard.
+        unsafe {
+            env::set_var("HOME", temp.path());
+        }
+        let result = f(temp.path());
+        match original_home {
+            Some(value) => unsafe {
+                env::set_var("HOME", value);
+            },
+            None => unsafe {
+                env::remove_var("HOME");
+            },
+        }
+        result
+    }
+
+    #[test]
+    fn returns_false_when_config_missing() {
+        with_temp_home(|_| {
+            let status = get_onboarding_completed().expect("should load default");
+            assert!(!status);
+        });
+    }
+
+    #[test]
+    fn reads_persisted_onboarding_flag() {
+        with_temp_home(|_| {
+            set_onboarding_completed(true).expect("set flag");
+            let status = get_onboarding_completed().expect("should read flag");
+            assert!(status);
+        });
+    }
+}

--- a/packages/core/src/application/init_kittynode.rs
+++ b/packages/core/src/application/init_kittynode.rs
@@ -22,3 +22,71 @@ pub fn init_kittynode() -> Result<()> {
     );
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::init_kittynode;
+    use crate::domain::config::Config;
+    use crate::infra::config::ConfigStore;
+    use std::env;
+    use tempfile::tempdir;
+
+    fn with_temp_home<F, R>(f: F) -> R
+    where
+        F: FnOnce(&std::path::Path) -> R,
+    {
+        let _lock = crate::ENV_GUARD.lock().expect("lock poisoned");
+        let original_home = env::var_os("HOME");
+        let temp = tempdir().expect("tempdir failed");
+        // Newer toolchains mark environment mutation unsafe; scope it with a guard.
+        unsafe {
+            env::set_var("HOME", temp.path());
+        }
+        let result = f(temp.path());
+        match original_home {
+            Some(value) => unsafe {
+                env::set_var("HOME", value);
+            },
+            None => unsafe {
+                env::remove_var("HOME");
+            },
+        }
+        result
+    }
+
+    #[test]
+    fn creates_default_config_when_missing() {
+        with_temp_home(|_| {
+            init_kittynode().expect("init should succeed");
+            let config = ConfigStore::load().expect("config should load");
+            assert!(!config.onboarding_completed);
+            assert_eq!(config.server_url, "");
+            assert_eq!(config.last_server_url, "");
+            assert!(!config.has_remote_server);
+        });
+    }
+
+    #[test]
+    fn preserves_existing_onboarding_flag() {
+        with_temp_home(|_| {
+            let mut config = Config {
+                onboarding_completed: true,
+                server_url: "https://example.com".to_string(),
+                last_server_url: "https://example.com".to_string(),
+                has_remote_server: true,
+                auto_start_docker: true,
+                ..Default::default()
+            };
+            ConfigStore::save_normalized(&mut config).expect("seed config");
+
+            init_kittynode().expect("init should succeed");
+
+            let config = ConfigStore::load().expect("config should load");
+            assert!(config.onboarding_completed);
+            assert_eq!(config.server_url, "");
+            assert_eq!(config.last_server_url, "");
+            assert!(!config.has_remote_server);
+            assert!(!config.auto_start_docker);
+        });
+    }
+}

--- a/packages/core/src/application/set_auto_start_docker.rs
+++ b/packages/core/src/application/set_auto_start_docker.rs
@@ -10,3 +10,49 @@ pub fn set_auto_start_docker(enabled: bool) -> Result<()> {
     info!("Set auto start docker to: {}", enabled);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::config::ConfigStore;
+    use std::env;
+    use tempfile::tempdir;
+
+    fn with_temp_home<F, R>(f: F) -> R
+    where
+        F: FnOnce(&std::path::Path) -> R,
+    {
+        let _lock = crate::ENV_GUARD.lock().expect("lock poisoned");
+        let original_home = env::var_os("HOME");
+        let temp = tempdir().expect("tempdir failed");
+        // Newer toolchains mark environment mutation unsafe; scope it with a guard.
+        unsafe {
+            env::set_var("HOME", temp.path());
+        }
+        let result = f(temp.path());
+        match original_home {
+            Some(value) => unsafe {
+                env::set_var("HOME", value);
+            },
+            None => unsafe {
+                env::remove_var("HOME");
+            },
+        }
+        result
+    }
+
+    #[test]
+    fn persists_auto_start_toggle() {
+        with_temp_home(|_| {
+            set_auto_start_docker(true).expect("toggle on");
+            let config = ConfigStore::load().expect("load config");
+            assert!(config.auto_start_docker);
+            assert!(!config.onboarding_completed);
+
+            set_auto_start_docker(false).expect("toggle off");
+            let config = ConfigStore::load().expect("reload config");
+            assert!(!config.auto_start_docker);
+            assert!(!config.onboarding_completed);
+        });
+    }
+}

--- a/packages/core/src/application/set_onboarding_completed.rs
+++ b/packages/core/src/application/set_onboarding_completed.rs
@@ -9,3 +9,49 @@ pub fn set_onboarding_completed(completed: bool) -> Result<()> {
     info!("Set onboarding completed to: {}", completed);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::config::ConfigStore;
+    use std::env;
+    use tempfile::tempdir;
+
+    fn with_temp_home<F, R>(f: F) -> R
+    where
+        F: FnOnce(&std::path::Path) -> R,
+    {
+        let _lock = crate::ENV_GUARD.lock().expect("lock poisoned");
+        let original_home = env::var_os("HOME");
+        let temp = tempdir().expect("tempdir failed");
+        // Newer toolchains mark environment mutation unsafe; scope it with a guard.
+        unsafe {
+            env::set_var("HOME", temp.path());
+        }
+        let result = f(temp.path());
+        match original_home {
+            Some(value) => unsafe {
+                env::set_var("HOME", value);
+            },
+            None => unsafe {
+                env::remove_var("HOME");
+            },
+        }
+        result
+    }
+
+    #[test]
+    fn persists_onboarding_toggle() {
+        with_temp_home(|_| {
+            set_onboarding_completed(true).expect("set true");
+            let config = ConfigStore::load().expect("load config");
+            assert!(config.onboarding_completed);
+            assert!(!config.auto_start_docker);
+
+            set_onboarding_completed(false).expect("set false");
+            let config = ConfigStore::load().expect("reload config");
+            assert!(!config.onboarding_completed);
+            assert!(!config.auto_start_docker);
+        });
+    }
+}

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -1,3 +1,9 @@
+#[cfg(test)]
+use std::sync::Mutex;
+
+#[cfg(test)]
+pub(crate) static ENV_GUARD: Mutex<()> = Mutex::new(());
+
 // Public modules
 pub mod api;
 


### PR DESCRIPTION
## Summary
- add linux socket candidate tests with environment isolation
- cover package catalog lookups and config toggles via temp home scaffolding
- preserve onboarding state init path while guarding env mutations behind a shared mutex

## Testing
- cargo test -p kittynode-core
