### PR TITLE
Add Axum-backed tests for core client HTTP flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,11 +179,46 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e529aee37b5c8206bb4bf4c44797127566d72f76952c970bd3d1e85de8f4e2"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.4",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -193,7 +228,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -205,6 +240,27 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -227,6 +283,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2140,6 +2207,7 @@ name = "kittynode-tauri"
 version = "0.74.0"
 dependencies = [
  "async-trait",
+ "axum 0.7.9",
  "eyre",
  "kittynode-core",
  "once_cell",
@@ -2161,7 +2229,7 @@ dependencies = [
 name = "kittynode-web"
 version = "0.15.0"
 dependencies = [
- "axum",
+ "axum 0.8.5",
  "eyre",
  "kittynode-core",
  "serde",
@@ -2315,6 +2383,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"

--- a/packages/app/src-tauri/Cargo.toml
+++ b/packages/app/src-tauri/Cargo.toml
@@ -36,3 +36,6 @@ tracing-subscriber = "0.3.20"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.9.0"
+
+[dev-dependencies]
+axum = { version = "0.7", features = ["json", "macros"] }

--- a/packages/app/src-tauri/src/core_client.rs
+++ b/packages/app/src-tauri/src/core_client.rs
@@ -25,6 +25,8 @@ fn normalize_base_url(server_url: &str) -> Option<String> {
 
 #[async_trait]
 pub trait CoreClient: Send + Sync {
+    #[cfg(test)]
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync);
     /// Retrieve the current package catalog from the core. Implementations may call the
     /// core directly (local) or proxy the HTTP API (remote) but must return the same data shape.
     async fn get_packages(&self) -> Result<HashMap<String, Package>>;
@@ -86,6 +88,11 @@ pub struct LocalCoreClient;
 
 #[async_trait]
 impl CoreClient for LocalCoreClient {
+    #[cfg(test)]
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
+
     async fn get_packages(&self) -> Result<HashMap<String, Package>> {
         api::get_packages()
     }
@@ -282,6 +289,11 @@ impl HttpCoreClient {
 
 #[async_trait]
 impl CoreClient for HttpCoreClient {
+    #[cfg(test)]
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
+    }
+
     async fn get_packages(&self) -> Result<HashMap<String, Package>> {
         self.get_json("/get_packages").await
     }
@@ -466,5 +478,173 @@ fn create_client(config: &Config) -> Result<Arc<dyn CoreClient>> {
         Ok(Arc::new(HttpCoreClient::new(&base_url)?) as Arc<dyn CoreClient>)
     } else {
         Ok(Arc::new(LocalCoreClient) as Arc<dyn CoreClient>)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        Json, Router,
+        extract::{Path, State},
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        routing::{get, post},
+    };
+    use eyre::Result as EyreResult;
+    use serde::Deserialize;
+    use std::collections::HashMap as StdHashMap;
+    use std::future::IntoFuture;
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+    use tokio::sync::Mutex as AsyncMutex;
+    use tokio::task::JoinHandle;
+
+    #[test]
+    fn normalize_base_url_handles_common_cases() {
+        assert_eq!(
+            super::normalize_base_url(" https://example.com/ "),
+            Some("https://example.com".to_string())
+        );
+        assert_eq!(
+            super::normalize_base_url("http://example.com"),
+            Some("http://example.com".to_string())
+        );
+        assert_eq!(super::normalize_base_url(""), None);
+        assert_eq!(super::normalize_base_url("example.com"), None);
+        assert_eq!(super::normalize_base_url("ftp://example.com"), None);
+    }
+
+    #[tokio::test]
+    async fn core_client_manager_reloads_between_local_and_remote() -> EyreResult<()> {
+        let (base_url, server_handle) = spawn_test_server().await?;
+
+        let mut config = Config::default();
+        config.server_url.clear();
+        let manager = CoreClientManager::new(&config)?;
+        assert!(manager.client().as_any().is::<LocalCoreClient>());
+
+        config.server_url = format!(" {}/ ", base_url);
+        manager.reload(&config)?;
+        let client = manager.client();
+        assert!(client.as_any().is::<HttpCoreClient>());
+
+        let capabilities = client.get_capabilities().await?;
+        assert_eq!(capabilities, vec!["remote-capability".to_string()]);
+
+        server_handle.abort();
+        let _ = server_handle.await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn http_core_client_handles_success_and_error_paths() -> EyreResult<()> {
+        let (base_url, server_handle) = spawn_test_server().await?;
+        let client = HttpCoreClient::new(&base_url)?;
+
+        assert_eq!(
+            client.get_capabilities().await?,
+            vec!["remote-capability".to_string()]
+        );
+        client.add_capability("beta").await?;
+        client.install_package("ok").await?;
+        let states = client
+            .get_package_runtime_states(&["alpha".to_string()])
+            .await?;
+        assert!(states.get("alpha").is_some_and(|state| state.running));
+        assert_eq!(
+            client.start_docker_if_needed().await?,
+            DockerStartStatus::Running
+        );
+
+        let install_err = client
+            .install_package("fail")
+            .await
+            .expect_err("expected failure");
+        assert!(install_err.to_string().contains("HTTP 500"));
+
+        assert!(client.is_docker_running().await?);
+        assert!(!client.is_docker_running().await?);
+        let docker_err = client
+            .is_docker_running()
+            .await
+            .expect_err("expected docker error");
+        assert!(docker_err.to_string().contains("418"));
+
+        server_handle.abort();
+        let _ = server_handle.await;
+        Ok(())
+    }
+
+    #[derive(Clone, Default)]
+    struct TestState {
+        docker_calls: Arc<AsyncMutex<usize>>,
+    }
+
+    #[derive(Deserialize)]
+    struct RuntimeStatesRequest {
+        names: Vec<String>,
+    }
+
+    async fn spawn_test_server() -> EyreResult<(String, JoinHandle<()>)> {
+        let state = TestState::default();
+        let router = Router::new()
+            .route("/get_capabilities", get(get_capabilities))
+            .route("/add_capability/:name", post(add_capability))
+            .route("/install_package/:name", post(install_package))
+            .route("/package_runtime", post(package_runtime_states))
+            .route("/start_docker_if_needed", post(start_docker_if_needed))
+            .route("/is_docker_running", get(is_docker_running))
+            .with_state(state);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let server = axum::serve(listener, router);
+        let handle = tokio::spawn(async move {
+            let _ = server.into_future().await;
+        });
+        Ok((format!("http://{}", addr), handle))
+    }
+
+    async fn get_capabilities() -> Json<Vec<String>> {
+        Json(vec!["remote-capability".to_string()])
+    }
+
+    async fn add_capability(Path(name): Path<String>) -> StatusCode {
+        assert_eq!(name, "beta");
+        StatusCode::NO_CONTENT
+    }
+
+    async fn install_package(Path(name): Path<String>) -> Response {
+        if name == "fail" {
+            (StatusCode::INTERNAL_SERVER_ERROR, "install failed").into_response()
+        } else {
+            StatusCode::NO_CONTENT.into_response()
+        }
+    }
+
+    async fn package_runtime_states(
+        Json(payload): Json<RuntimeStatesRequest>,
+    ) -> Json<StdHashMap<String, PackageRuntimeState>> {
+        let states = payload
+            .names
+            .into_iter()
+            .map(|name| (name, PackageRuntimeState { running: true }))
+            .collect();
+        Json(states)
+    }
+
+    async fn start_docker_if_needed() -> Json<DockerStartStatus> {
+        Json(DockerStartStatus::Running)
+    }
+
+    async fn is_docker_running(State(state): State<TestState>) -> Response {
+        let mut calls = state.docker_calls.lock().await;
+        *calls += 1;
+        match *calls {
+            1 => StatusCode::OK.into_response(),
+            2 => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+            _ => (StatusCode::IM_A_TEAPOT, "teapot").into_response(),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a test-only hook to introspect CoreClient implementations
- cover base URL normalization plus CoreClientManager reload paths
- drive HttpCoreClient against an in-process Axum server to verify success and error flows

## Testing
- cargo test -p kittynode-tauri