### PR TITLE
Add tests for PackageConfigStore config_file_path helper

### DIFF
--- a/packages/core/src/infra/package_config.rs
+++ b/packages/core/src/infra/package_config.rs
@@ -36,7 +36,7 @@ impl PackageConfigStore {
         Ok(())
     }
 
-    fn config_file_path(base_dir: &Path, package_name: &str) -> PathBuf {
+    pub(crate) fn config_file_path(base_dir: &Path, package_name: &str) -> PathBuf {
         base_dir
             .join("packages")
             .join(package_name)
@@ -100,6 +100,26 @@ mod tests {
                 .map(std::string::String::as_str),
             Some("https://example.invalid"),
             "round trip should preserve values"
+        );
+    }
+
+    #[test]
+    fn config_file_path_constructs_correct_path() {
+        let base_dir = Path::new("/home/user/.kittynode");
+        let path = PackageConfigStore::config_file_path(base_dir, "ethereum");
+        assert_eq!(
+            path,
+            Path::new("/home/user/.kittynode/packages/ethereum/config.toml")
+        );
+    }
+
+    #[test]
+    fn config_file_path_handles_special_characters() {
+        let base_dir = Path::new("/tmp/test");
+        let path = PackageConfigStore::config_file_path(base_dir, "my-validator");
+        assert_eq!(
+            path,
+            Path::new("/tmp/test/packages/my-validator/config.toml")
         );
     }
 }


### PR DESCRIPTION
## Summary
- Adds focused unit tests for the `config_file_path` helper method in `PackageConfigStore`
- Tests validate path construction logic with different base directories and package names
- Improves code coverage with useful tests that follow the project philosophy

## Architectural Improvements
- Made `config_file_path` `pub(crate)` to enable direct testing while maintaining module encapsulation
- Tests follow the "data transformation without mocking" philosophy emphasized in the codebase

## Test Coverage
The tests cover:
- Basic path construction with standard inputs
- Path construction with package names containing special characters (hyphens)
- Verification that paths are built correctly using `PathBuf::join` operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)