### PR TITLE
Add comprehensive unit tests for core domain models

### DIFF
--- a/packages/core/src/domain/container.rs
+++ b/packages/core/src/domain/container.rs
@@ -34,3 +34,145 @@ impl fmt::Display for Container {
         writeln!(f, "  Image: {}", self.image)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn container_display_formats_name_and_image() {
+        let container = Container {
+            name: "test-container".to_string(),
+            image: "nginx:latest".to_string(),
+            cmd: vec![],
+            port_bindings: HashMap::new(),
+            volume_bindings: vec![],
+            file_bindings: vec![],
+        };
+
+        let output = format!("{container}");
+
+        assert!(output.contains("- Name: test-container"));
+        assert!(output.contains("  Image: nginx:latest"));
+    }
+
+    #[test]
+    fn port_binding_serializes_with_camel_case_fields() {
+        let binding = PortBinding {
+            host_ip: Some("127.0.0.1".to_string()),
+            host_port: Some("8080".to_string()),
+        };
+
+        let json = serde_json::to_value(&binding).unwrap();
+
+        assert_eq!(json["hostIp"], "127.0.0.1");
+        assert_eq!(json["hostPort"], "8080");
+    }
+
+    #[test]
+    fn port_binding_handles_none_values() {
+        let binding = PortBinding {
+            host_ip: None,
+            host_port: None,
+        };
+
+        let json = serde_json::to_string(&binding).unwrap();
+        let deserialized: PortBinding = serde_json::from_str(&json).unwrap();
+
+        assert!(deserialized.host_ip.is_none());
+        assert!(deserialized.host_port.is_none());
+    }
+
+    #[test]
+    fn binding_serializes_with_camel_case_fields() {
+        let binding = Binding {
+            source: "/host/path".to_string(),
+            destination: "/container/path".to_string(),
+            options: Some("ro".to_string()),
+        };
+
+        let json = serde_json::to_value(&binding).unwrap();
+
+        assert_eq!(json["source"], "/host/path");
+        assert_eq!(json["destination"], "/container/path");
+        assert_eq!(json["options"], "ro");
+    }
+
+    #[test]
+    fn container_roundtrips_through_json() {
+        let mut port_bindings = HashMap::new();
+        port_bindings.insert(
+            "80/tcp".to_string(),
+            vec![PortBinding {
+                host_ip: Some("0.0.0.0".to_string()),
+                host_port: Some("8080".to_string()),
+            }],
+        );
+
+        let original = Container {
+            name: "web-server".to_string(),
+            image: "nginx:alpine".to_string(),
+            cmd: vec!["nginx".to_string(), "-g".to_string()],
+            port_bindings,
+            volume_bindings: vec![Binding {
+                source: "/data".to_string(),
+                destination: "/usr/share/nginx/html".to_string(),
+                options: Some("ro".to_string()),
+            }],
+            file_bindings: vec![],
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: Container = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.name, original.name);
+        assert_eq!(deserialized.image, original.image);
+        assert_eq!(deserialized.cmd.len(), 2);
+        assert_eq!(deserialized.cmd[0], "nginx");
+        assert_eq!(deserialized.port_bindings.len(), 1);
+        assert_eq!(deserialized.volume_bindings.len(), 1);
+        assert_eq!(deserialized.file_bindings.len(), 0);
+    }
+
+    #[test]
+    fn container_serializes_complex_structure() {
+        let mut port_bindings = HashMap::new();
+        port_bindings.insert(
+            "80/tcp".to_string(),
+            vec![
+                PortBinding {
+                    host_ip: Some("127.0.0.1".to_string()),
+                    host_port: Some("8080".to_string()),
+                },
+                PortBinding {
+                    host_ip: None,
+                    host_port: Some("8081".to_string()),
+                },
+            ],
+        );
+
+        let container = Container {
+            name: "complex".to_string(),
+            image: "app:v1".to_string(),
+            cmd: vec!["start".to_string()],
+            port_bindings,
+            volume_bindings: vec![Binding {
+                source: "/vol".to_string(),
+                destination: "/data".to_string(),
+                options: None,
+            }],
+            file_bindings: vec![Binding {
+                source: "/config".to_string(),
+                destination: "/etc/config".to_string(),
+                options: Some("rw".to_string()),
+            }],
+        };
+
+        let json = serde_json::to_value(&container).unwrap();
+
+        assert_eq!(json["name"], "complex");
+        assert_eq!(json["portBindings"]["80/tcp"].as_array().unwrap().len(), 2);
+        assert_eq!(json["volumeBindings"].as_array().unwrap().len(), 1);
+        assert_eq!(json["fileBindings"].as_array().unwrap().len(), 1);
+    }
+}

--- a/packages/core/src/domain/operational_state.rs
+++ b/packages/core/src/domain/operational_state.rs
@@ -16,3 +16,89 @@ pub struct OperationalState {
     pub can_manage: bool,
     pub diagnostics: Vec<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operational_mode_serializes_to_camel_case() {
+        let local = OperationalMode::Local;
+        let remote = OperationalMode::Remote;
+
+        let local_json = serde_json::to_string(&local).unwrap();
+        let remote_json = serde_json::to_string(&remote).unwrap();
+
+        assert_eq!(local_json, r#""local""#);
+        assert_eq!(remote_json, r#""remote""#);
+    }
+
+    #[test]
+    fn operational_mode_deserializes_from_camel_case() {
+        let local: OperationalMode = serde_json::from_str(r#""local""#).unwrap();
+        let remote: OperationalMode = serde_json::from_str(r#""remote""#).unwrap();
+
+        assert_eq!(local, OperationalMode::Local);
+        assert_eq!(remote, OperationalMode::Remote);
+    }
+
+    #[test]
+    fn operational_state_serializes_with_camel_case_fields() {
+        let state = OperationalState {
+            mode: OperationalMode::Local,
+            docker_running: true,
+            can_install: true,
+            can_manage: false,
+            diagnostics: vec!["test diagnostic".to_string()],
+        };
+
+        let json = serde_json::to_value(&state).unwrap();
+
+        assert_eq!(json["mode"], "local");
+        assert_eq!(json["dockerRunning"], true);
+        assert_eq!(json["canInstall"], true);
+        assert_eq!(json["canManage"], false);
+        assert_eq!(json["diagnostics"][0], "test diagnostic");
+    }
+
+    #[test]
+    fn operational_state_deserializes_from_camel_case_json() {
+        let json = r#"{
+            "mode": "remote",
+            "dockerRunning": false,
+            "canInstall": false,
+            "canManage": true,
+            "diagnostics": ["error 1", "error 2"]
+        }"#;
+
+        let state: OperationalState = serde_json::from_str(json).unwrap();
+
+        assert_eq!(state.mode, OperationalMode::Remote);
+        assert!(!state.docker_running);
+        assert!(!state.can_install);
+        assert!(state.can_manage);
+        assert_eq!(state.diagnostics.len(), 2);
+        assert_eq!(state.diagnostics[0], "error 1");
+        assert_eq!(state.diagnostics[1], "error 2");
+    }
+
+    #[test]
+    fn operational_state_roundtrips_through_json() {
+        let original = OperationalState {
+            mode: OperationalMode::Local,
+            docker_running: true,
+            can_install: false,
+            can_manage: true,
+            diagnostics: vec![],
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: OperationalState = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.mode, original.mode);
+        assert_eq!(deserialized.docker_running, original.docker_running);
+        assert_eq!(deserialized.can_install, original.can_install);
+        assert_eq!(deserialized.can_manage, original.can_manage);
+        assert_eq!(deserialized.diagnostics.len(), 0);
+    }
+}

--- a/packages/core/src/domain/package.rs
+++ b/packages/core/src/domain/package.rs
@@ -65,3 +65,144 @@ impl Package {
 pub struct PackageRuntimeState {
     pub running: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_config_new_creates_empty_values() {
+        let config = PackageConfig::new();
+
+        assert_eq!(config.values.len(), 0);
+    }
+
+    #[test]
+    fn package_config_default_creates_empty_values() {
+        let config = PackageConfig::default();
+
+        assert_eq!(config.values.len(), 0);
+    }
+
+    #[test]
+    fn package_config_serializes_values_as_camel_case() {
+        let mut config = PackageConfig::new();
+        config
+            .values
+            .insert("key1".to_string(), "value1".to_string());
+        config
+            .values
+            .insert("key2".to_string(), "value2".to_string());
+
+        let json = serde_json::to_value(&config).unwrap();
+
+        assert_eq!(json["values"]["key1"], "value1");
+        assert_eq!(json["values"]["key2"], "value2");
+    }
+
+    #[test]
+    fn package_config_roundtrips_through_json() {
+        let mut original = PackageConfig::new();
+        original.values.insert("foo".to_string(), "bar".to_string());
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: PackageConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.values.len(), 1);
+        assert_eq!(deserialized.values.get("foo"), Some(&"bar".to_string()));
+    }
+
+    #[test]
+    fn package_accessors_return_correct_values() {
+        let package = Package {
+            name: "ethereum".to_string(),
+            description: "Ethereum node".to_string(),
+            network_name: "eth-network".to_string(),
+            containers: vec![],
+            default_config: PackageConfig::new(),
+        };
+
+        assert_eq!(package.name(), "ethereum");
+        assert_eq!(package.description(), "Ethereum node");
+        assert_eq!(package.network_name(), "eth-network");
+    }
+
+    #[test]
+    fn package_display_formats_metadata() {
+        let package = Package {
+            name: "test-package".to_string(),
+            description: "A test package".to_string(),
+            network_name: "test-net".to_string(),
+            containers: vec![],
+            default_config: PackageConfig::new(),
+        };
+
+        let output = format!("{package}");
+
+        assert!(output.contains("Package: test-package"));
+        assert!(output.contains("Description: A test package"));
+        assert!(output.contains("Containers:"));
+    }
+
+    #[test]
+    fn package_display_includes_containers() {
+        let package = Package {
+            name: "web-app".to_string(),
+            description: "Web application".to_string(),
+            network_name: "web-net".to_string(),
+            containers: vec![Container {
+                name: "nginx".to_string(),
+                image: "nginx:latest".to_string(),
+                cmd: vec![],
+                port_bindings: HashMap::new(),
+                volume_bindings: vec![],
+                file_bindings: vec![],
+            }],
+            default_config: PackageConfig::new(),
+        };
+
+        let output = format!("{package}");
+
+        assert!(output.contains("Package: web-app"));
+        assert!(output.contains("- Name: nginx"));
+        assert!(output.contains("  Image: nginx:latest"));
+    }
+
+    #[test]
+    fn package_serializes_with_camel_case_fields() {
+        let package = Package {
+            name: "app".to_string(),
+            description: "desc".to_string(),
+            network_name: "net".to_string(),
+            containers: vec![],
+            default_config: PackageConfig::new(),
+        };
+
+        let json = serde_json::to_value(&package).unwrap();
+
+        assert_eq!(json["name"], "app");
+        assert_eq!(json["description"], "desc");
+        assert_eq!(json["networkName"], "net");
+        assert!(json["containers"].is_array());
+        assert!(json["defaultConfig"].is_object());
+    }
+
+    #[test]
+    fn package_runtime_state_serializes_with_camel_case() {
+        let state = PackageRuntimeState { running: true };
+
+        let json = serde_json::to_value(&state).unwrap();
+
+        assert_eq!(json["running"], true);
+    }
+
+    #[test]
+    fn package_runtime_state_roundtrips_through_json() {
+        let original = PackageRuntimeState { running: false };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: PackageRuntimeState = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.running, original.running);
+    }
+}

--- a/packages/core/src/domain/system_info.rs
+++ b/packages/core/src/domain/system_info.rs
@@ -42,3 +42,141 @@ pub struct DiskInfo {
     pub available_display: String,
     pub disk_type: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn processor_info_serializes_with_camel_case_fields() {
+        let processor = ProcessorInfo {
+            name: "Apple M1".to_string(),
+            cores: 8,
+            frequency_ghz: 3.2,
+            architecture: "arm64".to_string(),
+        };
+
+        let json = serde_json::to_value(&processor).unwrap();
+
+        assert_eq!(json["name"], "Apple M1");
+        assert_eq!(json["cores"], 8);
+        assert_eq!(json["frequencyGhz"], 3.2);
+        assert_eq!(json["architecture"], "arm64");
+    }
+
+    #[test]
+    fn memory_info_serializes_with_camel_case_fields() {
+        let memory = MemoryInfo {
+            total_bytes: 17179869184,
+            total_display: "16 GB".to_string(),
+        };
+
+        let json = serde_json::to_value(&memory).unwrap();
+
+        assert_eq!(json["totalBytes"], 17179869184_u64);
+        assert_eq!(json["totalDisplay"], "16 GB");
+    }
+
+    #[test]
+    fn disk_info_serializes_with_camel_case_fields() {
+        let disk = DiskInfo {
+            name: "Macintosh HD".to_string(),
+            mount_point: "/".to_string(),
+            total_bytes: 500000000000,
+            available_bytes: 200000000000,
+            total_display: "500 GB".to_string(),
+            used_display: "300 GB".to_string(),
+            available_display: "200 GB".to_string(),
+            disk_type: "SSD".to_string(),
+        };
+
+        let json = serde_json::to_value(&disk).unwrap();
+
+        assert_eq!(json["name"], "Macintosh HD");
+        assert_eq!(json["mountPoint"], "/");
+        assert_eq!(json["totalBytes"], 500000000000_u64);
+        assert_eq!(json["availableBytes"], 200000000000_u64);
+        assert_eq!(json["totalDisplay"], "500 GB");
+        assert_eq!(json["usedDisplay"], "300 GB");
+        assert_eq!(json["availableDisplay"], "200 GB");
+        assert_eq!(json["diskType"], "SSD");
+    }
+
+    #[test]
+    fn system_info_roundtrips_through_json() {
+        let original = SystemInfo {
+            processor: ProcessorInfo {
+                name: "Intel Core i7".to_string(),
+                cores: 4,
+                frequency_ghz: 2.8,
+                architecture: "x86_64".to_string(),
+            },
+            memory: MemoryInfo {
+                total_bytes: 8589934592,
+                total_display: "8 GB".to_string(),
+            },
+            storage: StorageInfo {
+                disks: vec![DiskInfo {
+                    name: "Main".to_string(),
+                    mount_point: "/".to_string(),
+                    total_bytes: 1000000000000,
+                    available_bytes: 500000000000,
+                    total_display: "1 TB".to_string(),
+                    used_display: "500 GB".to_string(),
+                    available_display: "500 GB".to_string(),
+                    disk_type: "HDD".to_string(),
+                }],
+            },
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: SystemInfo = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.processor.name, original.processor.name);
+        assert_eq!(deserialized.processor.cores, original.processor.cores);
+        assert_eq!(
+            deserialized.processor.frequency_ghz,
+            original.processor.frequency_ghz
+        );
+        assert_eq!(deserialized.memory.total_bytes, original.memory.total_bytes);
+        assert_eq!(deserialized.storage.disks.len(), 1);
+        assert_eq!(
+            deserialized.storage.disks[0].name,
+            original.storage.disks[0].name
+        );
+    }
+
+    #[test]
+    fn storage_info_handles_multiple_disks() {
+        let storage = StorageInfo {
+            disks: vec![
+                DiskInfo {
+                    name: "Disk 1".to_string(),
+                    mount_point: "/".to_string(),
+                    total_bytes: 1000,
+                    available_bytes: 500,
+                    total_display: "1 KB".to_string(),
+                    used_display: "500 B".to_string(),
+                    available_display: "500 B".to_string(),
+                    disk_type: "SSD".to_string(),
+                },
+                DiskInfo {
+                    name: "Disk 2".to_string(),
+                    mount_point: "/mnt".to_string(),
+                    total_bytes: 2000,
+                    available_bytes: 1000,
+                    total_display: "2 KB".to_string(),
+                    used_display: "1 KB".to_string(),
+                    available_display: "1 KB".to_string(),
+                    disk_type: "HDD".to_string(),
+                },
+            ],
+        };
+
+        let json = serde_json::to_value(&storage).unwrap();
+
+        assert_eq!(json["disks"].as_array().unwrap().len(), 2);
+        assert_eq!(json["disks"][0]["name"], "Disk 1");
+        assert_eq!(json["disks"][1]["name"], "Disk 2");
+    }
+}


### PR DESCRIPTION
## Summary

- Added 26 new unit tests for core domain models that previously had zero test coverage
- Tests cover serialization, deserialization, and data transformation for `OperationalState`, `SystemInfo`, `Container`, and `Package` types
- All tests follow the project's testing philosophy: pure data transformations without mocking
- Test count increased from 80 to 106 tests

## Details

### Files Changed

- `packages/core/src/domain/operational_state.rs`: 5 tests for enum serialization and struct field transformations
- `packages/core/src/domain/system_info.rs`: 6 tests for nested system info structures
- `packages/core/src/domain/container.rs`: 6 tests for container display and binding serialization
- `packages/core/src/domain/package.rs`: 9 tests for package configuration and display formatting

### Why This Matters

These domain models are critical data structures used throughout the application for API communication and internal state management. The tests ensure:

1. **API stability**: JSON serialization contracts remain consistent with camelCase field naming
2. **Data integrity**: Roundtrip serialization preserves all data correctly
3. **Display formatting**: User-facing output formats correctly
4. **Edge cases**: Optional fields and empty collections are handled properly

### Testing Philosophy

All tests follow the project's philosophy of focusing on data transformation:
- Input: Primitive data structures
- Transform: Through serialization, deserialization, or formatting
- Output: Verified results
- No mocking required

## Test Plan

- [x] All new tests pass (106/106)
- [x] Existing tests still pass
- [x] Linters pass (`just lint-rs`)
- [x] Tests demonstrate correct camelCase JSON field naming for API compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)