### PR TITLE
Add coverage for config persistence workflows

### DIFF
--- a/packages/core/src/application/mod.rs
+++ b/packages/core/src/application/mod.rs
@@ -58,3 +58,69 @@ pub use update_package_config::update_package_config;
 pub use web_service::{
     get_web_service_log_path, get_web_service_status, start_web_service, stop_web_service,
 };
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::ffi::{OsStr, OsString};
+    use std::sync::{LazyLock, Mutex, MutexGuard};
+
+    use tempfile::TempDir;
+
+    /// Serialises config-mutating tests across crates to avoid clobbering the
+    /// shared config override slot.
+    pub(crate) static CONFIG_ENV_GUARD: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    pub(crate) struct ConfigEnvOverride {
+        _guard: MutexGuard<'static, ()>,
+        previous: Option<OsString>,
+    }
+
+    fn set_env(value: Option<&OsStr>) {
+        unsafe {
+            match value {
+                Some(val) => std::env::set_var("KITTYNODE_HOME", val),
+                None => std::env::remove_var("KITTYNODE_HOME"),
+            }
+        }
+    }
+
+    pub(crate) fn override_kittnode_home_for_tests(path: &std::path::Path) -> ConfigEnvOverride {
+        override_kittnode_home_raw_for_tests(Some(path.as_os_str()))
+    }
+
+    pub(crate) fn override_kittnode_home_raw_for_tests(value: Option<&OsStr>) -> ConfigEnvOverride {
+        let guard = CONFIG_ENV_GUARD
+            .lock()
+            .expect("config override mutex poisoned");
+        let previous = std::env::var_os("KITTYNODE_HOME");
+        set_env(value);
+        ConfigEnvOverride {
+            _guard: guard,
+            previous,
+        }
+    }
+
+    impl Drop for ConfigEnvOverride {
+        fn drop(&mut self) {
+            let value = self.previous.take();
+            set_env(value.as_deref());
+        }
+    }
+
+    pub(crate) struct ConfigSandbox {
+        _override: ConfigEnvOverride,
+        _temp: TempDir,
+    }
+
+    impl ConfigSandbox {
+        pub(crate) fn new() -> Self {
+            let temp = tempfile::tempdir().expect("failed to create temporary directory");
+            let override_guard = override_kittnode_home_for_tests(temp.path());
+
+            Self {
+                _override: override_guard,
+                _temp: temp,
+            }
+        }
+    }
+}

--- a/packages/core/src/application/set_auto_start_docker.rs
+++ b/packages/core/src/application/set_auto_start_docker.rs
@@ -10,3 +10,31 @@ pub fn set_auto_start_docker(enabled: bool) -> Result<()> {
     info!("Set auto start docker to: {}", enabled);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::set_auto_start_docker;
+    use crate::application::test_support::ConfigSandbox;
+    use crate::infra::config::ConfigStore;
+
+    #[test]
+    fn set_auto_start_docker_persists_flag() {
+        let _sandbox = ConfigSandbox::new();
+
+        set_auto_start_docker(true).expect("enabling auto start should succeed");
+        assert!(
+            ConfigStore::load()
+                .expect("config should load after enabling")
+                .auto_start_docker,
+            "auto_start_docker flag should be true after enabling"
+        );
+
+        set_auto_start_docker(false).expect("disabling auto start should succeed");
+        assert!(
+            !ConfigStore::load()
+                .expect("config should load after disabling")
+                .auto_start_docker,
+            "auto_start_docker flag should be false after disabling"
+        );
+    }
+}

--- a/packages/core/src/application/set_onboarding_completed.rs
+++ b/packages/core/src/application/set_onboarding_completed.rs
@@ -9,3 +9,27 @@ pub fn set_onboarding_completed(completed: bool) -> Result<()> {
     info!("Set onboarding completed to: {}", completed);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::set_onboarding_completed;
+    use crate::application::get_onboarding_completed;
+    use crate::application::test_support::ConfigSandbox;
+
+    #[test]
+    fn set_onboarding_completed_roundtrip() {
+        let _sandbox = ConfigSandbox::new();
+
+        set_onboarding_completed(true).expect("enabling onboarding flag should succeed");
+        assert!(
+            get_onboarding_completed().expect("reading onboarding flag should succeed"),
+            "onboarding flag should be true after enabling"
+        );
+
+        set_onboarding_completed(false).expect("disabling onboarding flag should succeed");
+        assert!(
+            !get_onboarding_completed().expect("reading onboarding flag should succeed"),
+            "onboarding flag should be false after disabling"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- allow overriding the kittynode home via KITTYNODE_HOME and cover the edge cases
- add a shared ConfigSandbox helper so config-modifying tests operate in isolation
- add persistence tests for server URL, onboarding, and auto-start docker flows

## Testing
- cargo test -p kittynode-core
- just lint-rs