### PR TITLE
Add coverage test for web hello route

### DIFF
--- a/packages/web/tests/routes.rs
+++ b/packages/web/tests/routes.rs
@@ -1,5 +1,5 @@
 use axum::{
-    body::Body,
+    body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
 use tower::ServiceExt;
@@ -19,4 +19,27 @@ async fn get_package_config_route_is_registered() {
         .expect("service call failed");
 
     assert_ne!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn root_returns_hello_world_payload() {
+    let app = kittynode_web::app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .body(Body::empty())
+                .expect("failed to build request"),
+        )
+        .await
+        .expect("service call failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = to_bytes(response.into_body(), 1024)
+        .await
+        .expect("body read should succeed");
+    let body = std::str::from_utf8(&bytes).expect("response should be utf8");
+    assert_eq!(body, "Hello World!");
 }


### PR DESCRIPTION
## Summary
- add a route test that verifies the root endpoint returns Hello World
- exercise the response body to lift coverage for the web crate

## Testing
- cargo test -p kittynode-web